### PR TITLE
feat(ui): confirm before promoting a repository to publish next

### DIFF
--- a/src/components/ui/business/repository-mobile-view.tsx
+++ b/src/components/ui/business/repository-mobile-view.tsx
@@ -30,6 +30,7 @@ export function RepositoryMobileView({
   const [textInput, setTextInput] = useState('');
   const [textError, setTextError] = useState<string | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<Repository | null>(null);
+  const [showPromoteConfirm, setShowPromoteConfirm] = useState<Repository | null>(null);
   const [promotingId, setPromotingId] = useState<number | null>(null);
   const textInputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -294,7 +295,7 @@ export function RepositoryMobileView({
                         <Button
                           variant="ghost"
                           size="icon"
-                          onClick={() => handlePromoteRepository(repo)}
+                          onClick={() => setShowPromoteConfirm(repo)}
                           disabled={repo.id === nextPostId || promotingId !== null}
                           aria-label={repo.id === nextPostId ? 'Already next' : 'Publish next'}
                           className="h-8 w-8 text-muted-foreground hover:text-foreground disabled:opacity-50"
@@ -365,6 +366,22 @@ export function RepositoryMobileView({
           }
         }}
         onCancel={() => setShowDeleteConfirm(null)}
+      />
+
+      <ConfirmDialog
+        isOpen={showPromoteConfirm !== null}
+        title="Publish Next"
+        message="Publish this repository in the next posting cycle?"
+        confirmText="Publish"
+        cancelText="Cancel"
+        variant="info"
+        onConfirm={() => {
+          if (showPromoteConfirm) {
+            handlePromoteRepository(showPromoteConfirm);
+          }
+          setShowPromoteConfirm(null);
+        }}
+        onCancel={() => setShowPromoteConfirm(null)}
       />
     </>
   );

--- a/src/components/ui/business/repository-table.tsx
+++ b/src/components/ui/business/repository-table.tsx
@@ -78,6 +78,7 @@ export function RepositoryTable({
   const [textInput, setTextInput] = useState('');
   const [textError, setTextError] = useState<string | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<Repository | null>(null);
+  const [showPromoteConfirm, setShowPromoteConfirm] = useState<Repository | null>(null);
   const [promotingId, setPromotingId] = useState<number | null>(null);
   const textInputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -350,7 +351,7 @@ export function RepositoryTable({
                          <Button
                            variant="ghost"
                            size="icon"
-                           onClick={() => handlePromoteRepository(repo)}
+                           onClick={() => setShowPromoteConfirm(repo)}
                            disabled={repo.id === nextPostId || promotingId !== null}
                            aria-label={repo.id === nextPostId ? 'Already next' : 'Publish next'}
                            className="h-8 w-8 text-muted-foreground hover:text-foreground disabled:opacity-50"
@@ -444,6 +445,22 @@ export function RepositoryTable({
           }
         }}
         onCancel={() => setShowDeleteConfirm(null)}
+      />
+
+      <ConfirmDialog
+        isOpen={showPromoteConfirm !== null}
+        title="Publish Next"
+        message="Publish this repository in the next posting cycle?"
+        confirmText="Publish"
+        cancelText="Cancel"
+        variant="info"
+        onConfirm={() => {
+          if (showPromoteConfirm) {
+            handlePromoteRepository(showPromoteConfirm);
+          }
+          setShowPromoteConfirm(null);
+        }}
+        onCancel={() => setShowPromoteConfirm(null)}
       />
     </>
   );


### PR DESCRIPTION
## Problem

The **Publish next** (paper-plane / `Send`) action fired the promote API **immediately** on click, with no confirmation step — unlike delete, which shows a `ConfirmDialog`. It was easy to accidentally promote the wrong repository.

## Changes

Gate the action behind a confirmation dialog, reusing the existing `ConfirmDialog` pattern already used for delete:

- Add a `showPromoteConfirm` state.
- The `Send` button now opens a **"Publish Next"** dialog (`info` variant, *"Publish this repository in the next posting cycle?"*) instead of calling the promote handler directly.
- The promote request (and the existing success toast) only fire after the user confirms.

Applied identically to both views:
- `repository-table.tsx` (desktop)
- `repository-mobile-view.tsx` (mobile)

`handlePromoteRepository` and the toast are unchanged.

## Verification

`npm run build` passes. Manually: clicking the paper-plane opens the confirmation; Cancel is a no-op; Publish promotes and shows the toast — on both desktop and mobile.