### PR TITLE
fix(ui): accept any GitHub URL form and fix empty validation tooltip

### DIFF
--- a/src/components/ui/business/generate-form.tsx
+++ b/src/components/ui/business/generate-form.tsx
@@ -10,11 +10,40 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { Button } from '../base/button';
 import { Textarea } from '../base/textarea';
 
-// Function to validate GitHub repository URLs
-const isValidGithubRepoUrl = (url: string): boolean => {
-  // GitHub repository URL pattern
-  const githubUrlPattern = /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/?$/;
-  return githubUrlPattern.test(url.trim());
+// First path segments of github.com that can never be a repository owner
+const RESERVED_GITHUB_PATHS = new Set([
+  'orgs', 'settings', 'topics', 'sponsors', 'features', 'marketplace', 'apps',
+  'collections', 'trending', 'explore', 'notifications', 'pulls', 'issues', 'search',
+]);
+
+// Converts any form of GitHub repository reference into the canonical
+// https://github.com/<owner>/<repo> form, tolerating a missing scheme, "http://",
+// a "www." host, tracking query parameters, a fragment, a ".git" suffix and deep
+// paths such as "/tree/main/src". Returns null when the input is not a repository.
+const normalizeGithubRepoUrl = (input: string): string | null => {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null;
+
+  const host = parsed.hostname.toLowerCase();
+  if (host !== 'github.com' && host !== 'www.github.com') return null;
+
+  const segments = parsed.pathname.split('/').filter(Boolean);
+  if (segments.length < 2) return null;
+
+  const owner = segments[0];
+  const repo = segments[1].replace(/\.git$/, '');
+  if (!owner || !repo || RESERVED_GITHUB_PATHS.has(owner.toLowerCase())) return null;
+
+  return `https://github.com/${owner}/${repo}`;
 };
 
 const LANGUAGE_MAPPING = {
@@ -300,36 +329,50 @@ export function GenerateForm({ onManualGenerate, onAutoGenerate }: GenerateFormP
       try {
         setIsManualLoading(true);
 
-        // Check if input contains valid GitHub repository URLs
-        const urls = url.split(/\s+/).filter(u => u.trim());
-        const invalidUrls = urls.filter(u => !isValidGithubRepoUrl(u));
+        // Normalize the input: valid repository references are sent in canonical
+        // form, everything else is reported per URL without blocking the rest.
+        const inputs = url.split(/\s+/).filter(u => u.trim());
+        if (inputs.length === 0) {
+          toast.error('Enter at least one GitHub repository URL');
+          return;
+        }
 
-        if (invalidUrls.length > 0) {
-          // If there are invalid URLs, show error dialog with a single clear message
+        const normalizedUrls: string[] = [];
+        const invalidUrls: string[] = [];
+
+        inputs.forEach(input => {
+          const normalized = normalizeGithubRepoUrl(input);
+          if (normalized) {
+            if (!normalizedUrls.includes(normalized)) {
+              normalizedUrls.push(normalized);
+            }
+          } else {
+            invalidUrls.push(input);
+          }
+        });
+
+        const invalidMap: Record<string, string> = {};
+        invalidUrls.forEach(invalidUrl => {
+          invalidMap[invalidUrl] = `Not a GitHub repository URL. Expected format: https://github.com/username/repository`;
+        });
+
+        if (normalizedUrls.length === 0) {
           setAddedRepos([]);
-
-          // Use the first invalid URL as the example in the error message
-          const invalidUrl = invalidUrls[0];
-          setNotAddedRepos([invalidUrl]);
-
-          const errorMap: Record<string, string> = {};
-          errorMap[invalidUrl] = `Invalid GitHub repository URL format. URLs should be in the format: https://github.com/username/repository`;
-
-          setErrorMessages(errorMap);
+          setNotAddedRepos(invalidUrls);
+          setErrorMessages(invalidMap);
           setDialogContext('manual');
           setIsResultDialogOpen(true);
         } else {
-          // All URLs are valid, proceed with API call
           await new Promise(resolve => setTimeout(resolve, DEBUG_DELAY));
-          const response = await onManualGenerate(url);
+          const response = await onManualGenerate(normalizedUrls.join(' '));
 
           const added = response.added || [];
           const notAdded = response.dont_added || [];
 
           setAddedRepos(added as string[]);
-          setNotAddedRepos(notAdded as string[]);
+          setNotAddedRepos([...(notAdded as string[]), ...invalidUrls]);
 
-          const map: Record<string, string> = {};
+          const map: Record<string, string> = { ...invalidMap };
 
           // Map detailed errors if available
           if (response.error_details) {
@@ -339,7 +382,7 @@ export function GenerateForm({ onManualGenerate, onAutoGenerate }: GenerateFormP
           }
 
           // Fallback to error_message or default if detailed error missing
-          if (Object.keys(map).length === 0 && response.error_message && response.error_message.trim() !== '') {
+          if (response.error_message && response.error_message.trim() !== '') {
             (response.dont_added || []).forEach(repo => {
               if (!map[repo]) {
                 map[repo] = response.error_message!;

--- a/src/components/ui/business/prompt-settings.tsx
+++ b/src/components/ui/business/prompt-settings.tsx
@@ -57,6 +57,18 @@ export const PromptSettings = ({ isApiReady = true, onUnsavedChangesChange }: Pr
   });
   const [isValidatingLanguage, setIsValidatingLanguage] = useState(false);
 
+  // The validator can report a valid code without listing it (e.g. when the
+  // available-languages list can't be fetched), so the tooltip always needs a
+  // fallback — otherwise hovering the icon shows an empty bubble.
+  const languageValidationTooltip = languageValidation.isValid
+    ? languageValidation.validCodes.length > 0
+      ? `Valid: ${languageValidation.validCodes.join(', ')}`
+      : 'Valid language code'
+    : languageValidation.message ||
+      (languageValidation.invalidCodes.length > 0
+        ? `Invalid: ${languageValidation.invalidCodes.join(', ')}`
+        : 'Invalid language code');
+
   // Language validation cache helpers
   const LANG_VALIDATION_CACHE_KEY = 'promptLanguageValidationCache';
   const LANG_VALIDATION_TTL = 60 * 60 * 1000; // 1 hour
@@ -409,12 +421,7 @@ export const PromptSettings = ({ isApiReady = true, onUnsavedChangesChange }: Pr
                                   </div>
                                 </TooltipTrigger>
                                 <TooltipContent>
-                                  {languageValidation.isValid && languageValidation.validCodes.length > 0 && (
-                                    <div>Valid: {languageValidation.validCodes.join(', ')}</div>
-                                  )}
-                                  {!languageValidation.isValid && languageValidation.message && (
-                                    <div>{languageValidation.message}</div>
-                                  )}
+                                  <div>{languageValidationTooltip}</div>
                                 </TooltipContent>
                               </Tooltip>
                             )}

--- a/src/components/ui/common/result-dialog.tsx
+++ b/src/components/ui/common/result-dialog.tsx
@@ -88,14 +88,21 @@ export function ResultDialog({ isOpen, onClose, added, notAdded, errorMessages, 
                     className="bg-destructive/10 p-3 rounded-md mr-1 flex flex-col gap-1 border border-destructive/20"
                   >
                     <div className="flex items-center justify-between">
-                      <a
-                        href={repo}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="hover:underline break-all font-medium text-foreground"
-                      >
-                        {repo.replace('https://github.com/', '')}
-                      </a>
+                      {/* Rejected entries may be arbitrary user input (e.g. a URL
+                          that is not a repository), so only real repository URLs
+                          are rendered as links. */}
+                      {repo.startsWith('https://github.com/') ? (
+                        <a
+                          href={repo}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="hover:underline break-all font-medium text-foreground"
+                        >
+                          {repo.replace('https://github.com/', '')}
+                        </a>
+                      ) : (
+                        <span className="break-all font-medium text-foreground">{repo}</span>
+                      )}
                     </div>
                     <div className="text-sm dark:text-red-400 text-red-600 flex items-start gap-2">
                       <span>({errorMessages?.[repo] || "Repository already exists in database"})</span>

--- a/src/components/ui/common/settings-modal.tsx
+++ b/src/components/ui/common/settings-modal.tsx
@@ -252,6 +252,18 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
     resetFormState();
   }, [isOpen]);
 
+  // The validator can report a valid code without listing it (e.g. when the
+  // available-languages list can't be fetched), so the tooltip always needs a
+  // fallback — otherwise hovering the icon shows an empty bubble.
+  const languageValidationTooltip = languageValidation.isValid
+    ? languageValidation.validCodes.length > 0
+      ? `Valid: ${languageValidation.validCodes.join(', ')}`
+      : 'Valid language code'
+    : languageValidation.message ||
+      (languageValidation.invalidCodes.length > 0
+        ? `Invalid: ${languageValidation.invalidCodes.join(', ')}`
+        : 'Invalid language code');
+
   const validateLanguageCodes = useCallback(async (codes: string) => {
     const raw = codes || '';
     const normalized = normalizeCodesStr(raw);
@@ -586,12 +598,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
                                 </div>
                               </TooltipTrigger>
                               <TooltipContent>
-                                {languageValidation.isValid && languageValidation.validCodes.length > 0 && (
-                                  <div>Valid: {languageValidation.validCodes.join(', ')}</div>
-                                )}
-                                {!languageValidation.isValid && languageValidation.message && (
-                                  <div>{languageValidation.message}</div>
-                                )}
+                                <div>{languageValidationTooltip}</div>
                               </TooltipContent>
                             </Tooltip>
                           )}


### PR DESCRIPTION
Manual generation rejected URLs that a user realistically pastes (tracking parameter, `http://`, `www.`, `.git`, deep path like `/tree/main`), showed only the first invalid entry and dropped the valid ones with it.

- `normalizeGithubRepoUrl` canonicalizes input to `https://github.com/<owner>/<repo>`, mirroring `parser.NormalizeRepoURL` on the backend.
- All rejected entries are listed with their own message; valid URLs are still submitted.
- Whitespace-only input shows a toast instead of an empty result dialog.
- Rejected entries are no longer rendered as links (a `javascript:` token became a clickable URL in the app origin).
- Fixed the empty language-validation tooltip: after `resetFormState` the state is `{isValid: true, validCodes: []}` and both tooltip branches were false. Label now computed with fallbacks in the settings modal and AI settings.

Verified in the browser: mixed input of a tracking-param URL + junk tokens produces 1 added / 3 not-added with per-entry messages, junk rendered as `<span>` not `<a>`, and hovering the language tick shows "Valid language code".