### PR TITLE
feat(ui): replace horizontal tabs with side navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ function App() {
 
   const toastPosition = useResponsiveToast();
   const { isOpen: isSettingsOpen, onOpen: onSettingsOpen, onClose: onSettingsClose } = useDisclosure();
+  const { isOpen: isNavOpen, onOpen: onNavOpen, onClose: onNavClose } = useDisclosure();
   const isApiReady = isApiConfigured();
 
   const setErrorWithScroll = useCallback((errorMessage: string, toastId?: string) => {
@@ -210,6 +211,7 @@ function App() {
                 isSettingsOpen={isSettingsOpen}
                 onSettingsOpen={onSettingsOpen}
                 onSettingsClose={onSettingsClose}
+                onNavOpen={onNavOpen}
                 handleManualRefresh={handleManualRefresh}
                 loading={loading}
                 previewsLoading={previewsLoading}
@@ -255,6 +257,9 @@ function App() {
                   setOverviewTimeRange={setOverviewTimeRange}
                   overviewHistoryData={overviewHistoryData}
                   overviewLoading={overviewLoading}
+                  isNavOpen={isNavOpen}
+                  onNavOpen={onNavOpen}
+                  onNavClose={onNavClose}
                 />
               </DashboardLayout>
               <SettingsModal isOpen={isSettingsOpen} onClose={onSettingsClose} />

--- a/src/components/ui/layout/dashboard-content.tsx
+++ b/src/components/ui/layout/dashboard-content.tsx
@@ -9,8 +9,13 @@ import { CronJobs } from '../business/cron-jobs';
 import { ApiConfigs } from '../business/api-configs';
 import { CronJobHistory } from '../business/cron-job-history';
 import { RepositoryPreview } from '../business/repository-preview';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../base/tabs';
+import { Tabs, TabsContent } from '../base/tabs';
+import { DashboardSidebar } from './dashboard-sidebar';
+import { MobileNavDrawer } from './mobile-nav-drawer';
+import { NavEdgeSwipeZone } from './nav-edge-swipe-zone';
+import { NAV_KEYS, type DashboardTabKey } from '@/config/nav-items';
 import { useTabPersistence } from '../../../hooks/useTabPersistence';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { useSwipeable } from 'react-swipeable';
 import { useSwipeableTabs } from '@/hooks/useSwipeableTabs';
 import type { Repository, RepositorySortBy, RepositorySortOrder } from '../../../types';
@@ -18,8 +23,6 @@ import type { CronJob, CronJobHistory as CronJobHistoryType } from '../../../api
 import type { ManualGenerateResponse } from '../../../api';
 import { useApiConfigs } from '../../../hooks/useApiConfigs';
 import type { TimeRange } from '../../../hooks/useOverviewHistory';
-
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../base/tooltip';
 
 interface DashboardContentProps {
   stats: {
@@ -86,6 +89,9 @@ interface DashboardContentProps {
   setOverviewTimeRange: (range: TimeRange) => void;
   overviewHistoryData: CronJobHistoryType[];
   overviewLoading: boolean;
+  isNavOpen: boolean;
+  onNavOpen: () => void;
+  onNavClose: () => void;
 }
 
 export const DashboardContent = ({
@@ -127,7 +133,10 @@ export const DashboardContent = ({
   overviewTimeRange,
   setOverviewTimeRange,
   overviewHistoryData,
-  overviewLoading
+  overviewLoading,
+  isNavOpen,
+  onNavOpen,
+  onNavClose
 }: DashboardContentProps) => {
   const { activeTab, setActiveTab } = useTabPersistence('overview');
 
@@ -145,22 +154,8 @@ export const DashboardContent = ({
   // Track unsaved changes in AI Settings tab
   const [hasUnsavedSettingsChanges, setHasUnsavedSettingsChanges] = useState(false);
 
-  // Ordered tabs for swipe navigation (readonly tuple for type-safety)
-  const orderedTabs = ['overview', 'repositories', 'automation', 'integrations', 'settings'] as const;
-
   // Mobile detection flag
-  const [isMobile, setIsMobile] = useState(false);
-  useEffect(() => {
-    const mql = window.matchMedia('(max-width: 767px)');
-    const handleChange = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    // Initialize state
-    setIsMobile(mql.matches);
-    // Listen for viewport changes
-    mql.addEventListener?.('change', handleChange);
-    return () => {
-      mql.removeEventListener?.('change', handleChange);
-    };
-  }, []);
+  const isMobile = useIsMobile();
 
   // Track swipe-origin animations and direction (mobile-only)
   const [lastSwipeDir, setLastSwipeDir] = useState<"left" | "right" | null>(null);
@@ -169,9 +164,27 @@ export const DashboardContent = ({
   // Swipe intent handlers derived from useSwipeableTabs
   const { onSwipedLeft, onSwipedRight } = useSwipeableTabs(
     activeTab,
-    setActiveTab,
-    orderedTabs as unknown as string[],
+    setActiveTab as (tab: string) => void,
+    NAV_KEYS,
   );
+
+  // The drawer only mounts on mobile, so growing past the breakpoint would leave
+  // isNavOpen stuck true with no visible control to clear it - the drawer would
+  // then reopen by itself on the way back down.
+  useEffect(() => {
+    if (!isMobile && isNavOpen) {
+      onNavClose();
+    }
+  }, [isMobile, isNavOpen, onNavClose]);
+
+  // Selecting a nav item closes the mobile drawer and resets scroll position
+  const handleTabChange = (tab: string) => {
+    setActiveTab(tab as DashboardTabKey);
+    onNavClose();
+    if (isMobile) {
+      window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+    }
+  };
 
   // Initialize react-swipeable
   const swipeableHandlers = useSwipeable({
@@ -222,83 +235,32 @@ export const DashboardContent = ({
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-        {/* Mobile Tab Navigation - Full Width */}
-        <div className="md:hidden w-full mb-4 sm:mb-6">
-          <TabsList className="flex h-10 items-center justify-between rounded-md bg-muted p-1 text-muted-foreground w-full">
-            <TabsTrigger value="overview" className="whitespace-nowrap px-3 py-2 text-sm flex-1">
-              Overview
-            </TabsTrigger>
-            <TabsTrigger value="repositories" className="whitespace-nowrap px-3 py-2 text-sm flex-1">
-              Repos
-            </TabsTrigger>
-            <TabsTrigger value="automation" className="whitespace-nowrap px-3 py-2 text-sm flex-1">
-              Cron
-            </TabsTrigger>
-            <TabsTrigger value="integrations" className="whitespace-nowrap px-3 py-2 text-sm flex-1">
-              APIs
-            </TabsTrigger>
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex-1">
-                    <TabsTrigger value="settings" className="w-full whitespace-nowrap px-3 py-2 text-sm">
-                      AI Settings{hasUnsavedSettingsChanges && ' *'}
-                    </TabsTrigger>
-                  </div>
-                </TooltipTrigger>
-                {hasUnsavedSettingsChanges && (
-                  <TooltipContent>
-                    <p>You have unsaved changes</p>
-                  </TooltipContent>
-                )}
-              </Tooltip>
-            </TooltipProvider>
-          </TabsList>
-        </div>
+      <Tabs value={activeTab} onValueChange={handleTabChange} orientation="vertical" className="w-full">
+        <div className="md:flex md:items-start md:gap-6">
+          {isMobile ? (
+            <>
+              <MobileNavDrawer
+                open={isNavOpen}
+                onClose={onNavClose}
+                hasUnsavedSettingsChanges={hasUnsavedSettingsChanges}
+              />
+              {!isNavOpen && <NavEdgeSwipeZone onOpen={onNavOpen} />}
+            </>
+          ) : (
+            <DashboardSidebar hasUnsavedSettingsChanges={hasUnsavedSettingsChanges} />
+          )}
 
-        {/* Desktop Tab Navigation - Grid Layout */}
-        <TabsList className="hidden md:grid w-full grid-cols-5 gap-2 mb-4 sm:mb-6">
-          <TabsTrigger value="overview">
-            Overview
-          </TabsTrigger>
-          <TabsTrigger value="repositories">
-            Repositories
-          </TabsTrigger>
-          <TabsTrigger value="automation">
-            Cron
-          </TabsTrigger>
-          <TabsTrigger value="integrations">
-            Integrations
-          </TabsTrigger>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div>
-                  <TabsTrigger value="settings" className="w-full">
-                    AI Settings{hasUnsavedSettingsChanges && ' *'}
-                  </TabsTrigger>
-                </div>
-              </TooltipTrigger>
-              {hasUnsavedSettingsChanges && (
-                <TooltipContent>
-                  <p>You have unsaved changes</p>
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
-        </TabsList>
-
-        <div
-          {...(isMobile ? swipeableHandlers : {})}
-          className={`w-full ${
-            isMobile && animateOnSwipe && lastSwipeDir === 'left' ? 'motion-safe:animate-slide-fade-in-from-left' : ''
-          } ${
-            isMobile && animateOnSwipe && lastSwipeDir === 'right' ? 'motion-safe:animate-slide-fade-in-from-right' : ''
-          }`}
-        >
+          {/* min-w-0 keeps wide tables/charts from blowing out the flex row */}
+          <div
+            {...(isMobile ? swipeableHandlers : {})}
+            className={`w-full min-w-0 flex-1 ${
+              isMobile && animateOnSwipe && lastSwipeDir === 'left' ? 'motion-safe:animate-slide-fade-in-from-left' : ''
+            } ${
+              isMobile && animateOnSwipe && lastSwipeDir === 'right' ? 'motion-safe:animate-slide-fade-in-from-right' : ''
+            }`}
+          >
           {/* Overview Tab */}
-          <TabsContent value="overview" className="space-y-6">
+          <TabsContent value="overview" className="mt-0 space-y-6">
             {/* Top Grid: Previews & Static Stats */}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <RepositoryPreview
@@ -402,7 +364,7 @@ export const DashboardContent = ({
           </TabsContent>
 
           {/* Repositories Tab */}
-          <TabsContent value="repositories" className="space-y-6">
+          <TabsContent value="repositories" className="mt-0 space-y-6">
             {/* Generate Content */}
             <GenerateForm
               onManualGenerate={handleManualGenerate}
@@ -424,7 +386,7 @@ export const DashboardContent = ({
           </TabsContent>
 
           {/* Automation Tab */}
-          <TabsContent value="automation" className="space-y-6">
+          <TabsContent value="automation" className="mt-0 space-y-6">
             <CronJobs
               jobs={cronJobs}
               onJobsUpdate={onCronJobsUpdate}
@@ -459,7 +421,7 @@ export const DashboardContent = ({
           </TabsContent>
 
           {/* Integrations Tab */}
-          <TabsContent value="integrations" className="space-y-6">
+          <TabsContent value="integrations" className="mt-0 space-y-6">
             <ApiConfigs
               configs={apiConfigs}
               loading={apiConfigsLoading}
@@ -476,13 +438,14 @@ export const DashboardContent = ({
           <TabsContent
             value="settings"
             forceMount
-            className={activeTab !== 'settings' ? 'hidden' : ''}
+            className={activeTab !== 'settings' ? 'hidden' : 'mt-0'}
           >
             <PromptSettings
               isApiReady={isApiReady}
               onUnsavedChangesChange={setHasUnsavedSettingsChanges}
             />
           </TabsContent>
+          </div>
         </div>
       </Tabs>
     </div>

--- a/src/components/ui/layout/dashboard-layout.tsx
+++ b/src/components/ui/layout/dashboard-layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
-import { LayoutDashboard, RotateCw } from 'lucide-react';
+import { LayoutDashboard, Menu, RotateCw } from 'lucide-react';
 import { ThemeToggle } from '../common/theme-toggle';
 import { RefreshIndicator } from '../common/refresh-indicator';
 import { SettingsButton } from '../common/settings-button';
@@ -13,6 +13,7 @@ interface DashboardLayoutProps {
   isSettingsOpen: boolean;
   onSettingsOpen: () => void;
   onSettingsClose: () => void;
+  onNavOpen: () => void;
   handleManualRefresh: (showNotification?: boolean) => Promise<boolean>;
   loading: boolean;
   previewsLoading: boolean;
@@ -23,13 +24,14 @@ export const DashboardLayout = ({
   children,
   isRefreshing,
   onSettingsOpen,
+  onNavOpen,
   handleManualRefresh,
   loading,
 }: DashboardLayoutProps) => {
 
 
   const renderHeader = () => (
-    <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mb-6">
+    <div className="relative max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 mb-6">
       <Card>
         <CardHeader className="py-3 sm:py-4 px-3 sm:px-4">
           <div className="flex items-center justify-between">
@@ -44,6 +46,16 @@ export const DashboardLayout = ({
               </Link>
             </div>
             <div className="flex items-center space-x-2 sm:space-x-4 flex-shrink-0">
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onNavOpen}
+                className="h-8 w-8 sm:h-10 sm:w-10 md:hidden"
+                aria-label="Open navigation"
+                aria-haspopup="dialog"
+              >
+                <Menu className="h-4 w-4 sm:h-5 sm:w-5" />
+              </Button>
               <Button
                 variant="ghost"
                 size="icon"
@@ -66,7 +78,7 @@ export const DashboardLayout = ({
   );
 
   const renderFooter = () => (
-    <div className="max-w-7xl mx-auto px-3 sm:px-6 lg:px-8 mt-4 sm:mt-6">
+    <div className="max-w-screen-2xl mx-auto px-3 sm:px-6 lg:px-8 mt-4 sm:mt-6">
       <Card>
         <CardFooter className="p-3 sm:p-4 text-muted-foreground justify-center">
           <div className="text-center w-full text-sm">
@@ -92,11 +104,11 @@ export const DashboardLayout = ({
 
 
   return (
-    <div className="w-full h-full overflow-y-auto">
+    <div className="w-full">
       <RefreshIndicator isRefreshing={isRefreshing} />
       <div className="py-3 sm:py-6">
         {renderHeader()}
-        <main className="max-w-7xl mx-auto px-3 sm:px-6 lg:px-8 space-y-4 sm:space-y-6">
+        <main className="max-w-screen-2xl mx-auto px-3 sm:px-6 lg:px-8 space-y-4 sm:space-y-6">
           {children}
         </main>
         {renderFooter()}

--- a/src/components/ui/layout/dashboard-sidebar.tsx
+++ b/src/components/ui/layout/dashboard-sidebar.tsx
@@ -1,0 +1,27 @@
+import { TabsList } from '../base/tabs';
+import { TooltipProvider } from '../base/tooltip';
+import { Card } from './card';
+import { NavTabTrigger } from './nav-tab-trigger';
+import { NAV_ITEMS } from '@/config/nav-items';
+
+interface DashboardSidebarProps {
+  hasUnsavedSettingsChanges: boolean;
+}
+
+export const DashboardSidebar = ({ hasUnsavedSettingsChanges }: DashboardSidebarProps) => (
+  <aside className="hidden md:block w-60 shrink-0 md:sticky md:top-6 self-start">
+    <Card className="p-2">
+      <TooltipProvider>
+        <TabsList className="flex w-full flex-col items-stretch justify-start h-auto gap-1 bg-transparent p-0 text-muted-foreground">
+          {NAV_ITEMS.map((item) => (
+            <NavTabTrigger
+              key={item.key}
+              item={item}
+              showUnsavedMarker={item.key === 'settings' && hasUnsavedSettingsChanges}
+            />
+          ))}
+        </TabsList>
+      </TooltipProvider>
+    </Card>
+  </aside>
+);

--- a/src/components/ui/layout/mobile-nav-drawer.tsx
+++ b/src/components/ui/layout/mobile-nav-drawer.tsx
@@ -1,0 +1,66 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { useSwipeable } from 'react-swipeable';
+import { TabsList } from '../base/tabs';
+import { TooltipProvider } from '../base/tooltip';
+import { Button } from '../base/button';
+import { NavTabTrigger } from './nav-tab-trigger';
+import { NAV_ITEMS } from '@/config/nav-items';
+
+interface MobileNavDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  hasUnsavedSettingsChanges: boolean;
+}
+
+export const MobileNavDrawer = ({ open, onClose, hasUnsavedSettingsChanges }: MobileNavDrawerProps) => {
+  // Swipe right closes the drawer. Attached to an inner wrapper - useSwipeable
+  // owns its own ref and cannot be spread onto DialogPrimitive.Content.
+  const closeSwipeHandlers = useSwipeable({
+    onSwipedRight: onClose,
+    trackMouse: false,
+    delta: 40,
+  });
+
+  return (
+    <DialogPrimitive.Root
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) onClose();
+      }}
+    >
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0"
+        />
+        <DialogPrimitive.Content
+          className="fixed inset-y-0 right-0 z-50 flex h-full w-72 max-w-[80vw] flex-col gap-2 border-l bg-background p-4 shadow-lg duration-300 data-[state=open]:animate-in data-[state=open]:slide-in-from-right-full data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right-full"
+        >
+          <DialogPrimitive.Title className="sr-only">Navigation</DialogPrimitive.Title>
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-muted-foreground">Navigation</span>
+            <DialogPrimitive.Close asChild>
+              <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Close navigation">
+                <X className="h-4 w-4" />
+              </Button>
+            </DialogPrimitive.Close>
+          </div>
+          <div {...closeSwipeHandlers} className="flex-1">
+            <TooltipProvider>
+              <TabsList className="flex w-full flex-col items-stretch justify-start h-auto gap-1 bg-transparent p-0 text-muted-foreground">
+                {NAV_ITEMS.map((item) => (
+                  <NavTabTrigger
+                    key={item.key}
+                    item={item}
+                    onSelect={onClose}
+                    showUnsavedMarker={item.key === 'settings' && hasUnsavedSettingsChanges}
+                  />
+                ))}
+              </TabsList>
+            </TooltipProvider>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+};

--- a/src/components/ui/layout/nav-edge-swipe-zone.tsx
+++ b/src/components/ui/layout/nav-edge-swipe-zone.tsx
@@ -1,0 +1,31 @@
+import { useSwipeable } from 'react-swipeable';
+
+interface NavEdgeSwipeZoneProps {
+  onOpen: () => void;
+}
+
+/**
+ * Invisible strip pinned to the right viewport edge. Swiping inward from it
+ * (a left swipe) opens the mobile nav drawer.
+ *
+ * It sits above page content so touchstart never reaches the content tab-swipe
+ * handler - the two gestures stay structurally disjoint, no flag coordination.
+ * A separate strip is required because the content handler lives inside
+ * `<main className="px-3 …">`, so touches in the outermost ~12px never hit it.
+ */
+export const NavEdgeSwipeZone = ({ onOpen }: NavEdgeSwipeZoneProps) => {
+  const edgeHandlers = useSwipeable({
+    onSwipedLeft: onOpen,
+    trackMouse: false,
+    preventScrollOnSwipe: false,
+    delta: 30,
+  });
+
+  return (
+    <div
+      {...edgeHandlers}
+      aria-hidden="true"
+      className="md:hidden fixed inset-y-0 right-0 z-30 w-6 touch-pan-y bg-transparent"
+    />
+  );
+};

--- a/src/components/ui/layout/nav-tab-trigger.tsx
+++ b/src/components/ui/layout/nav-tab-trigger.tsx
@@ -1,0 +1,42 @@
+import { TabsTrigger } from '../base/tabs';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../base/tooltip';
+import type { NavItem } from '@/config/nav-items';
+
+interface NavTabTriggerProps {
+  item: NavItem;
+  /** Adds the ` *` marker and the "unsaved changes" tooltip (AI Settings only) */
+  showUnsavedMarker?: boolean;
+  /** Called on click in addition to onValueChange - fires even for the already active tab */
+  onSelect?: () => void;
+}
+
+export const NavTabTrigger = ({ item, showUnsavedMarker = false, onSelect }: NavTabTriggerProps) => {
+  const Icon = item.icon;
+
+  const trigger = (
+    <TabsTrigger
+      value={item.key}
+      onClick={onSelect}
+      className="w-full justify-start gap-3 h-10 px-3 text-sm data-[state=active]:bg-accent data-[state=active]:text-accent-foreground"
+    >
+      <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+      <span className="truncate">
+        {item.label}
+        {showUnsavedMarker && ' *'}
+      </span>
+    </TabsTrigger>
+  );
+
+  if (!showUnsavedMarker) {
+    return trigger;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+      <TooltipContent>
+        <p>You have unsaved changes</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+};

--- a/src/config/nav-items.ts
+++ b/src/config/nav-items.ts
@@ -1,0 +1,27 @@
+import { Gauge, FolderGit2, Clock, Plug, Bot, type LucideIcon } from 'lucide-react';
+
+export type DashboardTabKey =
+  | 'overview'
+  | 'repositories'
+  | 'automation'
+  | 'integrations'
+  | 'settings';
+
+export interface NavItem {
+  key: DashboardTabKey;
+  label: string;
+  shortLabel: string;
+  icon: LucideIcon;
+}
+
+export const NAV_ITEMS = [
+  { key: 'overview', label: 'Overview', shortLabel: 'Overview', icon: Gauge },
+  { key: 'repositories', label: 'Repositories', shortLabel: 'Repos', icon: FolderGit2 },
+  { key: 'automation', label: 'Cron', shortLabel: 'Cron', icon: Clock },
+  { key: 'integrations', label: 'Integrations', shortLabel: 'APIs', icon: Plug },
+  { key: 'settings', label: 'AI Settings', shortLabel: 'AI', icon: Bot },
+] as const satisfies readonly NavItem[];
+
+export const NAV_KEYS = NAV_ITEMS.map((item) => item.key) as DashboardTabKey[];
+
+export const DEFAULT_TAB: DashboardTabKey = 'overview';

--- a/src/hooks/useTabPersistence.ts
+++ b/src/hooks/useTabPersistence.ts
@@ -1,40 +1,45 @@
 import { useState } from 'react';
+import { NAV_KEYS, DEFAULT_TAB, type DashboardTabKey } from '@/config/nav-items';
 
 interface UseTabPersistenceReturn {
-  activeTab: string;
-  setActiveTab: (tab: string) => void;
+  activeTab: DashboardTabKey;
+  setActiveTab: (tab: DashboardTabKey) => void;
 }
 
 const TAB_STORAGE_KEY = 'dashboardActiveTab';
-const VALID_TABS = ['overview', 'repositories', 'automation', 'integrations', 'settings'] as const;
+
+const isValidTab = (tab: string): tab is DashboardTabKey =>
+  (NAV_KEYS as readonly string[]).includes(tab);
 
 // Helper function to get initial tab synchronously
-const getInitialTab = (defaultTab: string): string => {
+const getInitialTab = (defaultTab: DashboardTabKey): DashboardTabKey => {
   try {
     const savedTab = localStorage.getItem(TAB_STORAGE_KEY);
-    
+
     // Check if saved tab is valid
-    if (savedTab && (VALID_TABS as readonly string[]).includes(savedTab)) {
+    if (savedTab && isValidTab(savedTab)) {
       return savedTab;
     }
   } catch (error) {
     // Handle localStorage access errors (e.g., in private mode)
     console.warn('Failed to access localStorage for tab persistence:', error);
   }
-  
+
   // Fall back to default tab
   return defaultTab;
 };
 
-export const useTabPersistence = (defaultTab: string = 'overview'): UseTabPersistenceReturn => {
+export const useTabPersistence = (
+  defaultTab: DashboardTabKey = DEFAULT_TAB
+): UseTabPersistenceReturn => {
   // Use lazy initialization to load saved tab synchronously during state initialization
-  const [activeTab, setActiveTab] = useState<string>(() => getInitialTab(defaultTab));
+  const [activeTab, setActiveTab] = useState<DashboardTabKey>(() => getInitialTab(defaultTab));
 
   // Save tab to localStorage when it changes
-  const setActiveTabAndSave = (tab: string) => {
+  const setActiveTabAndSave = (tab: DashboardTabKey) => {
     try {
       // Validate tab before saving
-      if ((VALID_TABS as readonly string[]).includes(tab)) {
+      if (isValidTab(tab)) {
         localStorage.setItem(TAB_STORAGE_KEY, tab);
       }
       setActiveTab(tab);


### PR DESCRIPTION
Replaces the horizontal tab bar with a side menu: a permanent 240px sidebar on the left for desktop, and an off-canvas drawer on the right for mobile, opened by an edge swipe from the right edge or by the header hamburger.

## Why

The nav existed as two separate `TabsList` blocks in `dashboard-content.tsx` — a `md:hidden` mobile bar with abbreviated labels and a `hidden md:grid` desktop bar — both mounted at once and hidden with CSS. Every label, icon and the "unsaved changes" tooltip block existed in two copies.

## What changed

**Single source of truth.** `src/config/nav-items.ts` holds `NAV_ITEMS` (key/label/shortLabel/icon), and `NAV_KEYS` now feeds both `useTabPersistence` and `useSwipeableTabs`. One shared `NavTabTrigger` renders items for both the sidebar and the drawer, including the `*` marker and its tooltip — which now wraps the trigger only when there are unsaved changes, instead of always injecting an empty-tooltip `<div>` into the Radix collection.

**Kept Radix Tabs**, with `orientation="vertical"`. That preserves roving focus, `role="tablist"/"tab"/"tabpanel"`, `aria-selected`/`aria-controls`, and the `forceMount` + conditional `hidden` trick that holds unsaved `PromptSettings` form state. Only one `TabsList` mounts at a time now (driven by `isMobile`), so duplicate ids and `aria-controls` are gone from the DOM.

**Drawer on Radix Dialog** rather than a hand-rolled fixed div — focus trap, focus restore, Esc, overlay click and body scroll lock all come from the primitive. Composed from `DialogPrimitive` directly because `base/dialog.tsx` has centered-modal geometry baked in.

**Edge swipe on its own fixed 24px strip** (`z-30`). It intercepts `touchstart` before page content, so the gesture never reaches the content tab-swipe handler and the two stay structurally disjoint — existing swipe-to-change-tabs is unchanged. A check on `eventData.initial` in the existing handler would not have worked: that handler sits inside `<main className="px-3 …">`, so touches in the outermost ~12px never reach it.

## Two fixes that fell out of this

- **`h-full overflow-y-auto` dropped from the layout root.** `html`/`body` have no `height: 100%`, so `h-full` resolved to `auto` and the page always scrolled on the window — but `overflow-y: auto` still made that div a scroll container, which any `position: sticky` descendant would bind to and which never scrolls. Removing it is what lets the sidebar stick. Nothing else depended on it (checked the `closest('.overflow-y-auto')` in `settings-modal.tsx` — that only concerns touch targets inside the portalled modal).
- **`useIsMobile` replaces the local `matchMedia` duplicate** in `dashboard-content.tsx`. The local version started at `false` on every mount and only corrected after the first effect, so the mobile tree and swipe handlers rendered wrong for one frame.

## Layout

Page container widened `max-w-7xl` → `max-w-screen-2xl` (+256px) to offset the sidebar's 240px + gap. `mt-0` on the five panels clears the base `mt-2` from `base/tabs.tsx`, which used to separate panels from the tab bar above them and now just pushed the content column 8px below the sidebar. `min-w-0 flex-1` on the content column is required — the wide tables and Recharts containers would otherwise force the flex item past the row width.

The drawer only mounts on mobile, so an effect clears `isNavOpen` when the viewport grows past the breakpoint; otherwise the state would be stuck with no visible control to clear it, and the drawer would reopen by itself on the way back down.

## Verification

`npx tsc --noEmit` and `npm run build` clean (the two `useRepositories.ts` errors are pre-existing — confirmed against a clean tree; `npx eslint` does not run at all here, `eslint-plugin-react-hooks` is incompatible with the installed eslint 10). Checked in-browser at desktop width: sidebar 240px, `position: sticky` resolving, `aria-orientation="vertical"`, one tablist, five tabs. Mobile branch verified with the breakpoint forced: sidebar gone, hamburger present, 24px edge strip at `z-30`, drawer opening at `right: 0` / 288px / `z-50` with all five items and scroll lock applied.

Worth a manual pass on a real phone for the swipe gestures and the drawer close animation.