### PR TITLE
feat(archive): archive page and archive action for published posts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { toast } from './components/ui/common/toast-config';
 import { useResponsiveToast } from './hooks/useResponsiveToast';
 import { useDisclosure } from './hooks/useDisclosure';
 import { useRepositories } from './hooks/useRepositories';
+import { useArchive } from './hooks/useArchive';
 import { usePreviews } from './hooks/usePreviews';
 import { useCronJobs } from './hooks/useCronJobs';
 import { useCronJobHistory } from './hooks/useCronJobHistory';
@@ -17,6 +18,12 @@ import { DashboardLayout } from './components/ui/layout/dashboard-layout';
 import { DashboardContent } from './components/ui/layout/dashboard-content';
 import { SettingsModal } from './components/ui/common/settings-modal';
 import { isApiConfigured } from './utils/api-settings';
+import {
+  DEFAULT_REPOSITORY_SORT_BY,
+  DEFAULT_REPOSITORY_SORT_ORDER,
+  DEFAULT_REPOSITORY_STATUS_FILTER,
+  normalizeRepositoryFilterState,
+} from './utils/repositoryListUtils';
 
 function App() {
   const urlParams = new URLSearchParams(window.location.search);
@@ -53,6 +60,25 @@ function App() {
     applyNewData: applyRepoNewData,
     setLoading
   } = useRepositories({ isCacheBust, setErrorWithScroll });
+
+  const {
+    items: archiveItems,
+    all: archiveAll,
+    loading: archiveLoading,
+    filters: archiveFilters,
+    showFilters: archiveShowFilters,
+    currentPage: archiveCurrentPage,
+    totalPages: archiveTotalPages,
+    totalItems: archiveTotalItems,
+    newDataAvailable: archiveNewDataAvailable,
+    fetchArchive,
+    setFilter: archiveSetFilter,
+    setPage: archiveSetPage,
+    resetFilters: archiveResetFilters,
+    toggleFilters: archiveToggleFilters,
+    refreshArchive,
+    applyNewData: applyArchiveNewData
+  } = useArchive({ isCacheBust, setErrorWithScroll });
 
   const {
     latestPost,
@@ -156,6 +182,30 @@ function App() {
     setErrorWithScroll
   });
 
+  // Bulk archiving moves rows out of github_repositories, so both lists need a foreground refresh.
+  // Kept sequential and previews-free to stay within the Content Alchemist rate limit.
+  const handleArchiveMutation = useCallback(async () => {
+    await refreshArchive();
+
+    const savedFilters = normalizeRepositoryFilterState(
+      localStorage.getItem('dashboardStatusFilter') || DEFAULT_REPOSITORY_STATUS_FILTER,
+      localStorage.getItem('dashboardSortBy') || DEFAULT_REPOSITORY_SORT_BY,
+      localStorage.getItem('dashboardSortOrder') || DEFAULT_REPOSITORY_SORT_ORDER
+    );
+    const savedItemsPerPage = parseInt(localStorage.getItem('dashboardItemsPerPage') || '10', 10);
+
+    await fetchRepositories(
+      savedFilters.posted,
+      false,
+      savedItemsPerPage === 0,
+      savedItemsPerPage,
+      savedFilters.sortBy,
+      savedFilters.sortOrder,
+      1,
+      true
+    );
+  }, [refreshArchive, fetchRepositories]);
+
   useEffect(() => {
     if (!isApiReady) {
       return;
@@ -186,15 +236,17 @@ function App() {
       return;
     }
 
-    if (repoNewDataAvailable || previewsNewDataAvailable || cronJobsNewDataAvailable || cronJobHistoryNewDataAvailable) {
+    if (repoNewDataAvailable || previewsNewDataAvailable || cronJobsNewDataAvailable || cronJobHistoryNewDataAvailable || archiveNewDataAvailable) {
       if (repoNewDataAvailable) applyRepoNewData();
       if (previewsNewDataAvailable) applyPreviewsNewData();
       if (cronJobsNewDataAvailable) applyCronJobsNewData();
       if (cronJobHistoryNewDataAvailable) applyCronJobHistoryNewData();
+      if (archiveNewDataAvailable) applyArchiveNewData();
     }
   }, [
     repoNewDataAvailable, previewsNewDataAvailable, cronJobsNewDataAvailable, cronJobHistoryNewDataAvailable,
-    newDataDetails, applyRepoNewData, applyPreviewsNewData, applyCronJobsNewData, applyCronJobHistoryNewData, isRefreshing
+    archiveNewDataAvailable, newDataDetails, applyRepoNewData, applyPreviewsNewData, applyCronJobsNewData,
+    applyCronJobHistoryNewData, applyArchiveNewData, isRefreshing
   ]);
 
   return (
@@ -260,6 +312,21 @@ function App() {
                   isNavOpen={isNavOpen}
                   onNavOpen={onNavOpen}
                   onNavClose={onNavClose}
+                  archiveItems={archiveItems}
+                  archiveAll={archiveAll}
+                  archiveLoading={archiveLoading}
+                  archiveFilters={archiveFilters}
+                  archiveShowFilters={archiveShowFilters}
+                  archiveCurrentPage={archiveCurrentPage}
+                  archiveTotalPages={archiveTotalPages}
+                  archiveTotalItems={archiveTotalItems}
+                  archiveSetFilter={archiveSetFilter}
+                  archiveSetPage={archiveSetPage}
+                  archiveResetFilters={archiveResetFilters}
+                  archiveToggleFilters={archiveToggleFilters}
+                  fetchArchive={fetchArchive}
+                  refreshArchive={refreshArchive}
+                  onArchiveMutation={handleArchiveMutation}
                 />
               </DashboardLayout>
               <SettingsModal isOpen={isSettingsOpen} onClose={onSettingsClose} />

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,11 @@
 import type { Repository, RepositorySortBy, RepositorySortOrder } from './types';
+import type {
+  ArchiveOldRepositoriesResponse,
+  ArchiveRepositoryResponse,
+  GetArchivedRepositoriesRequest,
+  GetArchivedRepositoriesResponse,
+} from './types/archive';
+import { ARCHIVE_MAX_IDENTIFIERS } from "./utils/archiveUtils";
 import { getApiSettings, isApiConfigured } from "./utils/api-settings";
 import { queueRequest, createRequestSignature } from "./lib/requestQueue";
 
@@ -738,4 +745,146 @@ export async function updateRepositoryText(identifier: { id?: number; url?: stri
 
   // Use fallback logic
   return handleLanguageFallback(() => createRequest(textLanguage), textLanguage, createRequest);
+}
+
+/**
+ * Reads a Content Alchemist response body defensively.
+ *
+ * The middleware answers 401 and 429 with plain text, not the JSON envelope, so the body has to be
+ * read as text and parsed optimistically - calling response.json() first throws a SyntaxError that
+ * would mask the real status.
+ */
+async function parseAlchemistEnvelope<T>(response: Response, action: string): Promise<T> {
+  const raw = await response.text();
+
+  let parsed: unknown = null;
+  try {
+    parsed = raw ? JSON.parse(raw) : null;
+  } catch {
+    // Plain-text body (401 / 429 / 405) - handled below.
+  }
+
+  const envelopeMessage =
+    parsed && typeof parsed === 'object' && 'message' in parsed
+      ? String((parsed as { message?: unknown }).message ?? '')
+      : '';
+
+  if (!response.ok) {
+    if (response.status === 429) {
+      throw new Error("Rate limit exceeded. Please try again later.");
+    }
+    if (response.status === 401) {
+      throw new Error("Unauthorized. Check the Content Alchemist bearer token in settings.");
+    }
+    throw new Error(envelopeMessage || raw.trim() || `${action} failed with status: ${response.status}`);
+  }
+
+  if (!parsed) {
+    throw new Error(`${action} returned an unexpected response`);
+  }
+
+  return parsed as T;
+}
+
+export async function archiveRepositories(
+  identifiers: { ids: number[] } | { urls: string[] }
+): Promise<ArchiveRepositoryResponse> {
+  const { baseUrl, headers, isConfigured } = getApiConfig();
+
+  if (!isConfigured) {
+    return { status: "error", message: "API not configured", data: { archived: [], failed: [] } };
+  }
+
+  const entries = 'ids' in identifiers ? identifiers.ids : identifiers.urls;
+
+  if (!entries.length) {
+    throw new Error("No repositories selected for archiving");
+  }
+
+  if (entries.length > ARCHIVE_MAX_IDENTIFIERS) {
+    throw new Error(`A maximum of ${ARCHIVE_MAX_IDENTIFIERS} repositories can be archived per request`);
+  }
+
+  const fetchFunction = async () => {
+    const response = await fetch(`${baseUrl}/archive-repository/`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(identifiers),
+    });
+
+    return parseAlchemistEnvelope<ArchiveRepositoryResponse>(response, "Archiving repositories");
+  };
+
+  return createRequestSignature(
+    `${baseUrl}/archive-repository/`,
+    "POST",
+    identifiers
+  ).then(signature => queueRequest(fetchFunction, signature));
+}
+
+export async function archiveOldRepositories(
+  days: number,
+  dryRun: boolean
+): Promise<ArchiveOldRepositoriesResponse> {
+  const { baseUrl, headers, isConfigured } = getApiConfig();
+
+  if (!isConfigured) {
+    return {
+      status: "error",
+      message: "API not configured",
+      data: { archived_count: 0, dry_run: dryRun, archived: [] },
+    };
+  }
+
+  if (!Number.isInteger(days) || days < 1) {
+    throw new Error("Days must be a whole number greater than 0");
+  }
+
+  const requestBody = { days, dry_run: dryRun };
+
+  const fetchFunction = async () => {
+    const response = await fetch(`${baseUrl}/archive-old-repositories/`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(requestBody),
+    });
+
+    return parseAlchemistEnvelope<ArchiveOldRepositoriesResponse>(response, "Archiving old repositories");
+  };
+
+  return createRequestSignature(
+    `${baseUrl}/archive-old-repositories/`,
+    "POST",
+    requestBody
+  ).then(signature => queueRequest(fetchFunction, signature));
+}
+
+export async function getArchivedRepositories(
+  requestBody: GetArchivedRepositoriesRequest
+): Promise<GetArchivedRepositoriesResponse> {
+  const { baseUrl, headers, isConfigured } = getApiConfig();
+
+  if (!isConfigured) {
+    return {
+      status: "error",
+      message: "API not configured",
+      data: { all: 0, items: [], page: 1, page_size: 0, total_pages: 0, total_items: 0 },
+    };
+  }
+
+  const fetchFunction = async () => {
+    const response = await fetch(`${baseUrl}/get-archived-repositories/`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(requestBody),
+    });
+
+    return parseAlchemistEnvelope<GetArchivedRepositoriesResponse>(response, "Fetching archived repositories");
+  };
+
+  return createRequestSignature(
+    `${baseUrl}/get-archived-repositories/`,
+    "POST",
+    requestBody
+  ).then(signature => queueRequest(fetchFunction, signature));
 }

--- a/src/components/ui/base/button.tsx
+++ b/src/components/ui/base/button.tsx
@@ -5,6 +5,9 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
+  // No variant carries a real border: outline draws its edge with an inset ring (box-shadow) instead.
+  // A border participates in layout and rounds differently from a filled box at non-integer zoom,
+  // which made outline buttons render visibly shorter than filled ones next to them.
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring-subtle focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
@@ -12,8 +15,10 @@ const buttonVariants = cva(
         default: "bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-sm",
+        // Edge drawn as an inset shadow, not a border or a ring: a border would change the box
+        // geometry (see the base comment), and a ring would be replaced by the focus-visible ring
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground shadow-sm",
+          "shadow-[inset_0_0_0_1px_hsl(var(--input))] bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80 shadow-sm",
         ghost: "hover:bg-accent hover:text-accent-foreground",

--- a/src/components/ui/business/archive-filters.tsx
+++ b/src/components/ui/business/archive-filters.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useRef, useState } from 'react';
+import { Search, X } from 'lucide-react';
+import type { ArchiveFiltersProps, ArchiveSortBy, ArchiveSortOrder } from '@/types/archive';
+import {
+  ARCHIVE_SORT_BY_LABELS,
+  ARCHIVE_SORT_BY_OPTIONS,
+  hasActiveArchiveFilters,
+  isValidDateRange,
+} from '@/utils/archiveUtils';
+import { Card } from '../layout/card';
+import { Input } from '../base/input';
+import { Button } from '../base/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../base/select';
+import { Label } from '../base/label';
+import { CustomDateInput } from '@/components/ui/common/custom-date-input';
+
+// url/text are server-side substring filters, so keystrokes are debounced to stay under the rate limit
+const TEXT_FILTER_DEBOUNCE_MS = 600;
+
+export function ArchiveFilters({
+  filters,
+  loading,
+  onFilterChange,
+  onClearFilters,
+}: ArchiveFiltersProps) {
+  const [urlInput, setUrlInput] = useState(filters.url);
+  const [textInput, setTextInput] = useState(filters.text);
+
+  // onFilterChange gets a new identity on every archive state change; keeping it in a ref stops
+  // the debounce timers below from being cleared and restarted by unrelated re-renders
+  const onFilterChangeRef = useRef(onFilterChange);
+  useEffect(() => {
+    onFilterChangeRef.current = onFilterChange;
+  }, [onFilterChange]);
+
+  useEffect(() => {
+    setUrlInput(filters.url);
+  }, [filters.url]);
+
+  useEffect(() => {
+    setTextInput(filters.text);
+  }, [filters.text]);
+
+  useEffect(() => {
+    if (urlInput === filters.url) return;
+    const timer = setTimeout(() => onFilterChangeRef.current('url', urlInput), TEXT_FILTER_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [urlInput, filters.url]);
+
+  useEffect(() => {
+    if (textInput === filters.text) return;
+    const timer = setTimeout(() => onFilterChangeRef.current('text', textInput), TEXT_FILTER_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [textInput, filters.text]);
+
+  const hasFilters = hasActiveArchiveFilters(filters);
+
+  const dateRanges = [
+    { label: 'Date Added', fromKey: 'dateAddedFrom', toKey: 'dateAddedTo' },
+    { label: 'Date Posted', fromKey: 'datePostedFrom', toKey: 'datePostedTo' },
+    { label: 'Date Archived', fromKey: 'dateArchivedFrom', toKey: 'dateArchivedTo' },
+  ] as const;
+
+  return (
+    <Card className="mb-6 p-4">
+      <div className="flex flex-col gap-4">
+        {/* Text filters row */}
+        <div className="flex flex-col sm:flex-row gap-4">
+          <div className="flex-1 flex flex-col">
+            <Label className="mb-2">Url</Label>
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                type="text"
+                placeholder="Filter by URL..."
+                value={urlInput}
+                onChange={(e) => setUrlInput(e.target.value)}
+                className="pl-10 pr-8"
+              />
+              {urlInput && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setUrlInput('')}
+                  disabled={loading}
+                  className="absolute right-1 top-1/2 transform -translate-y-1/2 h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+                  title="Clear url filter"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              )}
+            </div>
+          </div>
+
+          <div className="flex-1 flex flex-col">
+            <Label className="mb-2">Text</Label>
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                type="text"
+                placeholder="Filter by text..."
+                value={textInput}
+                onChange={(e) => setTextInput(e.target.value)}
+                className="pl-10 pr-8"
+              />
+              {textInput && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setTextInput('')}
+                  disabled={loading}
+                  className="absolute right-1 top-1/2 transform -translate-y-1/2 h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+                  title="Clear text filter"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Date range rows */}
+        {dateRanges.map(({ label, fromKey, toKey }) => {
+          const from = filters[fromKey];
+          const to = filters[toKey];
+          const isValid = isValidDateRange(from, to);
+
+          return (
+            <div key={label} className="flex flex-col">
+              <Label className="mb-2">{label}</Label>
+              <div className="flex flex-col sm:flex-row gap-2">
+                <div className="flex-1">
+                  <CustomDateInput
+                    value={from}
+                    onChange={(value) => onFilterChange(fromKey, value)}
+                    placeholder={`Select ${label.toLowerCase()} from`}
+                  />
+                </div>
+                <div className="flex-1">
+                  <CustomDateInput
+                    value={to}
+                    onChange={(value) => onFilterChange(toKey, value)}
+                    placeholder={`Select ${label.toLowerCase()} to`}
+                  />
+                </div>
+              </div>
+              {!isValid && (
+                <p className="mt-1 text-xs text-destructive">
+                  The start date must not be later than the end date
+                </p>
+              )}
+            </div>
+          );
+        })}
+
+        {/* Controls row */}
+        <div className="flex flex-col sm:flex-row gap-4">
+          <div className="flex-1">
+            <Label className="mb-2">Sort By</Label>
+            <Select
+              value={filters.sortBy}
+              onValueChange={(value) => onFilterChange('sortBy', value as ArchiveSortBy)}
+              disabled={loading}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Sort by" />
+              </SelectTrigger>
+              <SelectContent>
+                {ARCHIVE_SORT_BY_OPTIONS.map((option) => (
+                  <SelectItem key={option} value={option}>
+                    {ARCHIVE_SORT_BY_LABELS[option]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex-1">
+            <Label className="mb-2">Sort Order</Label>
+            <Select
+              value={filters.sortOrder}
+              onValueChange={(value) => onFilterChange('sortOrder', value as ArchiveSortOrder)}
+              disabled={loading}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Sort order" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="desc">Newest First</SelectItem>
+                <SelectItem value="asc">Oldest First</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex-1">
+            <Label className="mb-2">Page Size</Label>
+            <Select
+              value={filters.pageSize.toString()}
+              onValueChange={(value) => onFilterChange('pageSize', Number(value))}
+              disabled={loading}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Page size" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="0">All</SelectItem>
+                <SelectItem value="5">5</SelectItem>
+                <SelectItem value="10">10</SelectItem>
+                <SelectItem value="20">20</SelectItem>
+                <SelectItem value="50">50</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {hasFilters && (
+          <div className="flex justify-end">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onClearFilters}
+              disabled={loading}
+            >
+              Clear Filters
+            </Button>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/ui/business/archive-list.tsx
+++ b/src/components/ui/business/archive-list.tsx
@@ -1,0 +1,106 @@
+import { Archive, ChevronDown, Filter } from 'lucide-react';
+import type { ArchiveListProps } from '@/types/archive';
+import { countActiveArchiveFilters, hasActiveArchiveFilters } from '@/utils/archiveUtils';
+import { Card, CardContent, CardHeader, CardTitle } from '../layout/card';
+import { Button } from '../base/button';
+import { Badge } from '../common/badge';
+import { ArchiveFilters } from './archive-filters';
+import { ArchiveTable } from './archive-table';
+import { ArchiveMobileView } from './archive-mobile-view';
+import { RepositoryPagination } from './repository-pagination';
+
+export function ArchiveList({
+  items,
+  all,
+  loading,
+  isApiReady,
+  filters,
+  showFilters,
+  currentPage,
+  totalPages,
+  totalItems,
+  onFilterChange,
+  onClearFilters,
+  onToggleFilters,
+  onPageChange,
+}: ArchiveListProps) {
+  const activeFiltersCount = countActiveArchiveFilters(filters);
+  const hasFilters = hasActiveArchiveFilters(filters);
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between p-6">
+        <div className="flex items-center flex-1">
+          <Archive className="h-5 w-5 text-muted-foreground mr-2" />
+          <CardTitle className="text-lg">Archived</CardTitle>
+          {isApiReady && all > 0 && (
+            <span className="ml-2 text-sm text-muted-foreground">{all} total</span>
+          )}
+        </div>
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onToggleFilters}
+          className="flex items-center gap-2"
+        >
+          <Filter className="h-4 w-4" />
+          Filters
+          <ChevronDown className={`h-4 w-4 transition-transform ${showFilters ? 'rotate-180' : ''}`} />
+          {activeFiltersCount > 0 && (
+            <Badge variant="default" className="ml-1">
+              {activeFiltersCount}
+            </Badge>
+          )}
+        </Button>
+      </CardHeader>
+
+      <CardContent className="px-6 pb-6">
+        {showFilters && (
+          <ArchiveFilters
+            filters={filters}
+            loading={loading}
+            onFilterChange={onFilterChange}
+            onClearFilters={onClearFilters}
+          />
+        )}
+
+        <div className="overflow-x-auto">
+          <div className="md:block hidden">
+            <ArchiveTable
+              items={items}
+              loading={loading}
+              isApiReady={isApiReady}
+              totalItems={totalItems}
+              itemsPerPage={filters.pageSize}
+              hasFilters={hasFilters}
+            />
+          </div>
+
+          <div className="md:hidden block">
+            <ArchiveMobileView
+              items={items}
+              loading={loading}
+              isApiReady={isApiReady}
+              totalItems={totalItems}
+              itemsPerPage={filters.pageSize}
+              hasFilters={hasFilters}
+            />
+          </div>
+        </div>
+
+        {/* Filtering happens server-side, so searchTerm stays empty - a value would hide the page buttons */}
+        <RepositoryPagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          totalItems={totalItems}
+          itemsPerPage={filters.pageSize}
+          searchTerm=""
+          filteredItemsCount={items.length}
+          loading={loading}
+          onPageChange={onPageChange}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/ui/business/archive-mobile-view.tsx
+++ b/src/components/ui/business/archive-mobile-view.tsx
@@ -1,0 +1,110 @@
+import type { ArchiveMobileViewProps } from '@/types/archive';
+import { formatDate } from '@/utils/date-format';
+import { RepositoryLink } from '@/components/ui/common/repository-link';
+import { TruncatedText } from '@/components/ui/common/truncated-text';
+import { Label } from '../base/label';
+
+export function ArchiveMobileView({
+  items,
+  loading,
+  isApiReady,
+  totalItems,
+  itemsPerPage,
+  hasFilters,
+}: ArchiveMobileViewProps) {
+  const renderLoadingSkeleton = () => (
+    Array.from({ length: itemsPerPage || 5 }).map((_, index) => (
+      <div key={index} className={`bg-card border ${index !== (itemsPerPage || 5) - 1 ? 'border-b' : ''} p-4 mb-4 animate-pulse`}>
+        <div className="space-y-3">
+          <div>
+            <div className="h-3 bg-muted rounded w-8 mb-2"></div>
+            <div className="h-4 bg-muted rounded w-12"></div>
+          </div>
+          <div>
+            <div className="h-3 bg-muted rounded w-16 mb-2"></div>
+            <div className="h-4 bg-muted rounded w-full"></div>
+          </div>
+          <div>
+            <div className="h-3 bg-muted rounded w-20 mb-2"></div>
+            <div className="h-4 bg-muted rounded w-full"></div>
+          </div>
+        </div>
+      </div>
+    ))
+  );
+
+  const renderEmptyState = () => (
+    <div className="bg-card border rounded-lg p-4 mb-4 text-center">
+      <p className="text-sm text-muted-foreground">
+        {hasFilters ? 'No archived repositories match these filters' : 'No archived repositories yet'}
+      </p>
+    </div>
+  );
+
+  const renderApiNotReady = () => (
+    <div className="bg-card border rounded-lg p-4 mb-4">
+      <p className="text-sm text-muted-foreground text-center">
+        Data could not be loaded because API keys are not configured
+      </p>
+    </div>
+  );
+
+  const renderCards = () => (
+    items.map((item, index) => (
+      <div key={item.id} className={`bg-card border ${index !== items.length - 1 ? 'border-b' : ''} p-4 hover:bg-muted/50 transition-colors`}>
+        <div className="space-y-4">
+          <div>
+            <Label className="text-xs font-medium uppercase text-muted-foreground">Archive ID</Label>
+            <p className="mt-1 text-sm font-medium">
+              {item.id}
+            </p>
+          </div>
+
+          <div>
+            <Label className="text-xs font-medium uppercase text-muted-foreground">Url</Label>
+            <div className="mt-1 min-w-0">
+              <RepositoryLink url={item.url} className="underline" />
+            </div>
+          </div>
+
+          <div>
+            <Label className="text-xs font-medium uppercase text-muted-foreground">Text</Label>
+            <div className="mt-1 text-sm text-foreground">
+              {item.text ? <TruncatedText text={item.text} maxChars={150} /> : <p>-</p>}
+            </div>
+          </div>
+
+          <div>
+            <Label className="text-xs font-medium uppercase text-muted-foreground">Date Added</Label>
+            <p className="mt-1 text-sm text-foreground">
+              {item.date_added ? formatDate(item.date_added) : '-'}
+            </p>
+          </div>
+
+          <div>
+            <Label className="text-xs font-medium uppercase text-muted-foreground">Date Posted</Label>
+            <p className="mt-1 text-sm text-foreground">
+              {item.date_posted ? formatDate(item.date_posted) : '-'}
+            </p>
+          </div>
+
+          <div>
+            <Label className="text-xs font-medium uppercase text-muted-foreground">Date Archived</Label>
+            <p className="mt-1 text-sm text-foreground">
+              {item.date_archived ? formatDate(item.date_archived) : '-'}
+            </p>
+          </div>
+        </div>
+      </div>
+    ))
+  );
+
+  return (
+    <>
+      {!isApiReady ? renderApiNotReady() :
+       loading ? renderLoadingSkeleton() :
+       totalItems === 0 || items.length === 0 ? renderEmptyState() :
+       renderCards()}
+    </>
+  );
+}

--- a/src/components/ui/business/archive-old-repositories.tsx
+++ b/src/components/ui/business/archive-old-repositories.tsx
@@ -1,0 +1,256 @@
+import { memo, useState } from 'react';
+import { Archive, CalendarClock, Eye } from 'lucide-react';
+import { archiveOldRepositories } from '@/api';
+import type {
+  ArchiveOldRepositoriesProps,
+  ArchiveOldRepositoriesResponse,
+  ArchiveOperationItem,
+} from '@/types/archive';
+import { DEFAULT_ARCHIVE_DAYS } from '@/utils/archiveUtils';
+import { formatDate } from '@/utils/date-format';
+import { useRepositoryLocalStorage } from '@/hooks/useRepositoryLocalStorage';
+import { toast } from '@/components/ui/common/toast-config';
+import { ConfirmDialog } from '@/components/ui/common/confirm-dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/base/table';
+import { Card, CardContent, CardHeader, CardTitle } from '../layout/card';
+import { Button } from '../base/button';
+import { Input } from '../base/input';
+import { Label } from '../base/label';
+import { Badge } from '../common/badge';
+
+const toastOptions = {
+  duration: 4000,
+};
+
+type PreviewData = ArchiveOldRepositoriesResponse['data'];
+
+/**
+ * Memoized on the items array so editing the days field does not re-render the rows.
+ * A preview can be hundreds of entries, each formatting a date - re-rendering them per keystroke
+ * makes the input lag.
+ *
+ * The whole list is rendered inside a fixed-height scroll box. The scrollbar is left native so it
+ * matches the page's own; the color-scheme declaration in index.css makes it dark in dark theme.
+ */
+const PreviewTable = memo(function PreviewTable({ items }: { items: ArchiveOperationItem[] }) {
+  return (
+    <div className="max-h-[420px] overflow-y-auto">
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            {/* Sticky so the columns stay labelled while scrolling a long preview */}
+            <TableHead className="sticky top-0 z-10 h-10 bg-card">Repository</TableHead>
+            <TableHead className="sticky top-0 z-10 h-10 w-[200px] bg-card text-right">Date Posted</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {items.map((item, index) => (
+            <TableRow key={`${item.id ?? item.url}-${index}`}>
+              <TableCell className="py-2">
+                <a
+                  href={item.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-primary hover:text-primary/80 break-all"
+                >
+                  {item.url}
+                </a>
+              </TableCell>
+              <TableCell className="py-2 text-right text-muted-foreground whitespace-nowrap">
+                {item.date_posted ? formatDate(item.date_posted) : '-'}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+});
+
+export function ArchiveOldRepositories({ isApiReady, onArchived }: ArchiveOldRepositoriesProps) {
+  const { getStoredValue, setStoredValue } = useRepositoryLocalStorage();
+  const [days, setDays] = useState<string>(
+    String(getStoredValue('archiveOlderThanDays', DEFAULT_ARCHIVE_DAYS))
+  );
+  // The preview is kept in state so the real run does not need a second dry-run request
+  const [preview, setPreview] = useState<PreviewData | null>(null);
+  const [previewDays, setPreviewDays] = useState<number | null>(null);
+  const [pending, setPending] = useState<'preview' | 'archive' | null>(null);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const parsedDays = Number(days);
+  const daysError = !Number.isInteger(parsedDays) || parsedDays < 1
+    ? 'Days must be a whole number greater than 0'
+    : null;
+
+  const handleDaysChange = (value: string) => {
+    setDays(value);
+    // The preview stays on screen while the field is edited - it is only marked stale (see
+    // isPreviewCurrent), which is what keeps it from authorizing a run for a different cutoff
+
+    const parsed = Number(value);
+    if (Number.isInteger(parsed) && parsed >= 1) {
+      setStoredValue('archiveOlderThanDays', parsed);
+    }
+  };
+
+  const handlePreview = async () => {
+    if (daysError || pending) return;
+
+    try {
+      setPending('preview');
+      const response = await archiveOldRepositories(parsedDays, true);
+      setPreview(response.data);
+      setPreviewDays(parsedDays);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to preview old repositories';
+      toast.error(message, { ...toastOptions, id: 'archive-old-preview-error' });
+    } finally {
+      setPending(null);
+    }
+  };
+
+  const handleArchive = async () => {
+    // previewDays !== parsedDays means the field was edited after the preview - never archive that
+    if (daysError || pending || preview === null || previewDays !== parsedDays) return;
+
+    try {
+      setPending('archive');
+      const response = await archiveOldRepositories(parsedDays, false);
+      const archivedCount = response.data?.archived_count ?? 0;
+
+      toast.success(
+        archivedCount === 1
+          ? 'Archived 1 repository'
+          : `Archived ${archivedCount} repositories`,
+        { ...toastOptions, id: 'archive-old' }
+      );
+
+      setPreview(null);
+      setPreviewDays(null);
+      await onArchived();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to archive old repositories';
+      toast.error(message, { ...toastOptions, id: 'archive-old-error' });
+    } finally {
+      setPending(null);
+    }
+  };
+
+  const isPreviewCurrent = preview !== null && previewDays === parsedDays;
+  const previewCount = preview?.archived_count ?? 0;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center p-6">
+        <CalendarClock className="h-5 w-5 text-muted-foreground mr-2" />
+        <CardTitle className="text-lg">Archive Old Posts</CardTitle>
+      </CardHeader>
+
+      <CardContent className="px-6 pb-6 space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Moves published repositories to the archive based on their publication date. Preview first to
+          see exactly what would be archived.
+        </p>
+
+        <div className="flex flex-col sm:flex-row sm:items-end gap-4">
+          <div className="sm:max-w-[220px] flex-1">
+            <Label className="mb-2">Older than (days)</Label>
+            <Input
+              type="number"
+              min={1}
+              step={1}
+              value={days}
+              onChange={(e) => handleDaysChange(e.target.value)}
+              disabled={!isApiReady || pending !== null}
+            />
+          </div>
+
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              onClick={handlePreview}
+              disabled={!isApiReady || !!daysError || pending !== null}
+              className="flex items-center gap-2"
+            >
+              <Eye className="h-4 w-4" />
+              {pending === 'preview' ? 'Loading...' : 'Preview'}
+            </Button>
+
+            <Button
+              onClick={() => setShowConfirm(true)}
+              disabled={!isApiReady || !!daysError || pending !== null || !isPreviewCurrent || previewCount === 0}
+              className="flex items-center gap-2"
+            >
+              <Archive className="h-4 w-4" />
+              {pending === 'archive'
+                ? 'Archiving...'
+                : isPreviewCurrent && previewCount > 0
+                  ? `Archive ${previewCount}`
+                  : 'Archive'}
+            </Button>
+          </div>
+        </div>
+
+        {daysError && <p className="text-xs text-destructive">{daysError}</p>}
+
+        {!isApiReady && (
+          <p className="text-sm text-muted-foreground">
+            Archiving is unavailable because API keys are not configured
+          </p>
+        )}
+
+        {preview !== null && (
+          previewCount === 0 ? (
+            <div className="rounded-lg border border-warning/20 bg-warning/10 p-4 text-sm text-foreground">
+              No published repositories older than {previewDays} days
+            </div>
+          ) : (
+            <div className={`rounded-lg border overflow-hidden ${isPreviewCurrent ? '' : 'opacity-60'}`}>
+              <div className="flex flex-wrap items-center justify-between gap-2 border-b bg-muted/30 px-4 py-3">
+                <div className="flex items-center gap-2">
+                  <Badge variant="warning">{previewCount}</Badge>
+                  <span className="text-sm font-medium">
+                    {previewCount === 1 ? 'repository' : 'repositories'} would be archived
+                  </span>
+                </div>
+                {isPreviewCurrent ? (
+                  <span className="text-xs text-muted-foreground">
+                    published more than {previewDays} days ago &middot; oldest first
+                  </span>
+                ) : (
+                  <span className="text-xs text-warning">
+                    This preview is for {previewDays} days &middot; press Preview to refresh
+                  </span>
+                )}
+              </div>
+
+              <PreviewTable items={preview!.archived} />
+            </div>
+          )
+        )}
+      </CardContent>
+
+      <ConfirmDialog
+        isOpen={showConfirm}
+        title="Archive Old Posts"
+        message={`Archive ${previewCount} published ${previewCount === 1 ? 'repository' : 'repositories'} older than ${parsedDays} days? They will be removed from Posts and cannot be restored from the dashboard.`}
+        confirmText="Archive"
+        cancelText="Cancel"
+        variant="warning"
+        onConfirm={() => {
+          setShowConfirm(false);
+          handleArchive();
+        }}
+        onCancel={() => setShowConfirm(false)}
+      />
+    </Card>
+  );
+}

--- a/src/components/ui/business/archive-table.tsx
+++ b/src/components/ui/business/archive-table.tsx
@@ -1,0 +1,114 @@
+import type { ArchiveTableProps } from '@/types/archive';
+import { formatDate } from '@/utils/date-format';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/base/table';
+import { Skeleton } from '@/components/ui/common/skeleton';
+import { RepositoryLink } from '@/components/ui/common/repository-link';
+import { TruncatedText } from '@/components/ui/common/truncated-text';
+
+const COLUMN_COUNT = 6;
+
+export function ArchiveTable({
+  items,
+  loading,
+  isApiReady,
+  totalItems,
+  itemsPerPage,
+  hasFilters,
+}: ArchiveTableProps) {
+  const renderLoadingSkeleton = () => (
+    Array.from({ length: itemsPerPage || 5 }).map((_, index) => (
+      <TableRow key={index}>
+        <TableCell>
+          <Skeleton className="h-4 w-12" />
+        </TableCell>
+        <TableCell>
+          <Skeleton className="h-4 w-full" />
+        </TableCell>
+        <TableCell>
+          <Skeleton className="h-4 w-full" />
+        </TableCell>
+        <TableCell>
+          <Skeleton className="h-4 w-24" />
+        </TableCell>
+        <TableCell>
+          <Skeleton className="h-4 w-24" />
+        </TableCell>
+        <TableCell>
+          <Skeleton className="h-4 w-24" />
+        </TableCell>
+      </TableRow>
+    ))
+  );
+
+  const renderEmptyState = () => (
+    <TableRow>
+      <TableCell colSpan={COLUMN_COUNT} className="text-center py-8 text-sm text-muted-foreground">
+        {hasFilters ? 'No archived repositories match these filters' : 'No archived repositories yet'}
+      </TableCell>
+    </TableRow>
+  );
+
+  const renderApiNotReady = () => (
+    <TableRow>
+      <TableCell colSpan={COLUMN_COUNT} className="text-center py-4 text-sm text-muted-foreground">
+        Data could not be loaded because API keys are not configured
+      </TableCell>
+    </TableRow>
+  );
+
+  const renderRows = () => (
+    items.map((item) => (
+      <TableRow key={item.id} className="group">
+        <TableCell className="font-medium">
+          {item.id}
+        </TableCell>
+        <TableCell className="min-w-0">
+          <RepositoryLink url={item.url} />
+        </TableCell>
+        <TableCell>
+          {item.text ? <TruncatedText text={item.text} maxChars={150} /> : <p>-</p>}
+        </TableCell>
+        {/* Formatted dates are fixed-length, so keep them on one line instead of wrapping mid-value */}
+        <TableCell className="whitespace-nowrap">
+          {item.date_added ? formatDate(item.date_added) : '-'}
+        </TableCell>
+        <TableCell className="whitespace-nowrap">
+          {item.date_posted ? formatDate(item.date_posted) : '-'}
+        </TableCell>
+        <TableCell className="whitespace-nowrap">
+          {item.date_archived ? formatDate(item.date_archived) : '-'}
+        </TableCell>
+      </TableRow>
+    ))
+  );
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          {/* Widths sum to 100% - six columns at the Posts table's fractions would overflow to 108%.
+              nowrap keeps every header on one line at these widths. */}
+          <TableHead className="w-[9%] whitespace-nowrap">Archive ID</TableHead>
+          <TableHead className="w-[17%] whitespace-nowrap">Url</TableHead>
+          <TableHead className="w-[32%] whitespace-nowrap">Text</TableHead>
+          <TableHead className="w-[14%] whitespace-nowrap">Date Added</TableHead>
+          <TableHead className="w-[14%] whitespace-nowrap">Date Posted</TableHead>
+          <TableHead className="w-[14%] whitespace-nowrap">Date Archived</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {!isApiReady ? renderApiNotReady() :
+         loading ? renderLoadingSkeleton() :
+         totalItems === 0 || items.length === 0 ? renderEmptyState() :
+         renderRows()}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/components/ui/business/overview-charts.tsx
+++ b/src/components/ui/business/overview-charts.tsx
@@ -17,6 +17,7 @@ import { useIsMobile } from '../../../hooks/useIsMobile';
 interface OverviewChartsProps {
   posted: number;
   unposted: number;
+  archived?: number;
   statsLoading?: boolean;
   cronJobs?: CronJob[];
   cronJobsLoading?: boolean;
@@ -31,6 +32,7 @@ interface OverviewChartsProps {
 export function OverviewCharts({
   posted,
   unposted,
+  archived = 0,
   statsLoading = false,
   historyData,
   historyLoading,
@@ -226,7 +228,7 @@ export function OverviewCharts({
                   </div>
                 </div>
                 {/* Static Stats */}
-                <div className="mt-4 flex items-center text-xs text-muted-foreground border-b border-border/50 pb-2 mb-2">
+                <div className="mt-4 flex flex-wrap items-center text-xs text-muted-foreground border-b border-border/50 pb-2 mb-2">
                   <div className="flex items-center gap-1.5">
                     <div className="w-1.5 h-1.5 rounded-full bg-success" />
                     <span>{posted} posted</span>
@@ -235,6 +237,12 @@ export function OverviewCharts({
                   <div className="flex items-center gap-1.5">
                     <div className="w-1.5 h-1.5 rounded-full bg-warning" />
                     <span>{unposted} pending</span>
+                  </div>
+                  <span className="mx-2">•</span>
+                  {/* Archived rows live in a separate table, so they are not part of totalRepos */}
+                  <div className="flex items-center gap-1.5">
+                    <div className="w-1.5 h-1.5 rounded-full bg-muted-foreground" />
+                    <span>{archived} archived</span>
                   </div>
                 </div>
                 {/* Dynamic Period Stats */}

--- a/src/components/ui/business/repository-list.tsx
+++ b/src/components/ui/business/repository-list.tsx
@@ -23,9 +23,10 @@ interface RepositoryListProps {
   pageSize: number;
   loading: boolean;
   isApiReady?: boolean;
+  onRepositoryArchived?: () => void | Promise<void>;
 }
 
-export function RepositoryList({ 
+export function RepositoryList({
   repositories, 
   fetchRepositories, 
   fetchPreviews,
@@ -34,8 +35,9 @@ export function RepositoryList({
   totalPages, 
   currentPage: initialPage, 
   pageSize: initialPageSize, 
-  loading, 
-  isApiReady = true 
+  loading,
+  isApiReady = true,
+  onRepositoryArchived
 }: RepositoryListProps) {
   const {
     searchTerm,
@@ -138,9 +140,10 @@ export function RepositoryList({
               searchTerm={searchTerm}
               nextPostId={nextPostId}
               onRepositoryUpdate={handleRepositoryUpdate}
+              onRepositoryArchived={onRepositoryArchived}
             />
           </div>
-          
+
           <div className="md:hidden block">
             <RepositoryMobileView
               repositories={filteredItems}
@@ -151,6 +154,7 @@ export function RepositoryList({
               searchTerm={searchTerm}
               nextPostId={nextPostId}
               onRepositoryUpdate={handleRepositoryUpdate}
+              onRepositoryArchived={onRepositoryArchived}
             />
           </div>
         </div>

--- a/src/components/ui/business/repository-mobile-view.tsx
+++ b/src/components/ui/business/repository-mobile-view.tsx
@@ -3,8 +3,9 @@ import { RepositoryMobileViewProps } from '@/types/repositoryList';
 import { Repository } from '@/types';
 import { TruncatedText } from '@/components/ui/common/truncated-text';
 import { formatDate } from '@/utils/date-format';
-import { deleteRepository, promoteRepositoryToNext, updateRepositoryText } from '@/api';
-import { Pencil, Check, X, Trash2, AlertCircle, Send } from 'lucide-react';
+import { archiveRepositories, deleteRepository, promoteRepositoryToNext, updateRepositoryText } from '@/api';
+import { Pencil, Check, X, Trash2, AlertCircle, Archive, Send } from 'lucide-react';
+import { describeArchiveFailure, isStaleArchiveFailure, summarizeArchiveResult } from '@/utils/archiveUtils';
 import { toast } from '@/components/ui/common/toast-config';
 import { ConfirmDialog } from '@/components/ui/common/confirm-dialog';
 import { RepositoryLink } from '@/components/ui/common/repository-link';
@@ -23,13 +24,16 @@ export function RepositoryMobileView({
   itemsPerPage,
   searchTerm,
   nextPostId,
-  onRepositoryUpdate
+  onRepositoryUpdate,
+  onRepositoryArchived
 }: RepositoryMobileViewProps) {
   const [localRepositories, setLocalRepositories] = useState<Repository[]>(repositories);
   const [editingText, setEditingText] = useState<{ id: number; text: string } | null>(null);
   const [textInput, setTextInput] = useState('');
   const [textError, setTextError] = useState<string | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<Repository | null>(null);
+  const [showArchiveConfirm, setShowArchiveConfirm] = useState<Repository | null>(null);
+  const [archivingId, setArchivingId] = useState<number | null>(null);
   const [showPromoteConfirm, setShowPromoteConfirm] = useState<Repository | null>(null);
   const [promotingId, setPromotingId] = useState<number | null>(null);
   const textInputRef = useRef<HTMLTextAreaElement>(null);
@@ -143,6 +147,62 @@ export function RepositoryMobileView({
         ...toastOptions,
         id: 'content-alchemist-error'
       });
+    }
+  };
+
+  const handleArchiveRepository = async (repo: Repository) => {
+    if (archivingId !== null) return;
+
+    try {
+      setArchivingId(repo.id);
+      // Optimistic update - archiving moves the row out of the repositories table
+      setLocalRepositories(prevRepos =>
+        prevRepos.filter(r => r.id !== repo.id)
+      );
+
+      const result = await archiveRepositories({ ids: [repo.id] });
+      const { archivedCount, firstFailure } = summarizeArchiveResult(result);
+
+      if (archivedCount > 0) {
+        toast.success(`Repository archived successfully`, {
+          ...toastOptions,
+          id: `archive-${repo.id}`
+        });
+      } else if (firstFailure) {
+        // The row's posted flag can be stale, so put it back unless the server says it is already gone
+        if (!isStaleArchiveFailure(firstFailure)) {
+          setLocalRepositories(repositories);
+        }
+        toast.error(describeArchiveFailure(firstFailure), {
+          ...toastOptions,
+          id: `archive-error-${repo.id}`
+        });
+      } else {
+        // Nothing archived and nothing reported as failed - never treat that as success, or the row
+        // disappears as if it had been archived
+        setLocalRepositories(repositories);
+        toast.error(result.message || 'Failed to archive repository', {
+          ...toastOptions,
+          id: `archive-error-${repo.id}`
+        });
+      }
+
+      if (onRepositoryUpdate) {
+        await onRepositoryUpdate();
+      }
+      if (onRepositoryArchived) {
+        await onRepositoryArchived();
+      }
+    } catch (error) {
+      // Rollback on error
+      setLocalRepositories(repositories);
+      const message = error instanceof Error ? error.message : 'Failed to connect to Content Alchemist API';
+      toast.error(message, {
+        ...toastOptions,
+        id: 'content-alchemist-error'
+      });
+    } finally {
+      setArchivingId(null);
     }
   };
 
@@ -313,15 +373,30 @@ export function RepositoryMobileView({
                       >
                         <Pencil className="h-4 w-4" />
                       </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => setShowDeleteConfirm(repo)}
-                        className="h-8 w-8 text-muted-foreground hover:text-destructive"
-                        title="Delete repository"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
+                      {/* Only published repositories can be archived, so they get Archive instead of Delete */}
+                      {repo.posted ? (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setShowArchiveConfirm(repo)}
+                          disabled={archivingId !== null}
+                          aria-label="Archive repository"
+                          className="h-8 w-8 text-muted-foreground hover:text-warning disabled:opacity-50"
+                          title="Archive repository"
+                        >
+                          <Archive className="h-4 w-4" />
+                        </Button>
+                      ) : (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setShowDeleteConfirm(repo)}
+                          className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                          title="Delete repository"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      )}
                     </div>
                   </div>
                 )}
@@ -366,6 +441,22 @@ export function RepositoryMobileView({
           }
         }}
         onCancel={() => setShowDeleteConfirm(null)}
+      />
+
+      <ConfirmDialog
+        isOpen={showArchiveConfirm !== null}
+        title="Archive Repository"
+        message="Move this published repository to the archive? It will be removed from Posts and cannot be restored from the dashboard."
+        confirmText="Archive"
+        cancelText="Cancel"
+        variant="warning"
+        onConfirm={() => {
+          if (showArchiveConfirm) {
+            handleArchiveRepository(showArchiveConfirm);
+          }
+          setShowArchiveConfirm(null);
+        }}
+        onCancel={() => setShowArchiveConfirm(null)}
       />
 
       <ConfirmDialog

--- a/src/components/ui/business/repository-table.tsx
+++ b/src/components/ui/business/repository-table.tsx
@@ -2,8 +2,9 @@ import { useState, useEffect, useRef } from 'react';
 import { RepositoryTableProps } from '@/types/repositoryList';
 import { Repository } from '@/types';
 import { formatDate } from '@/utils/date-format';
-import { deleteRepository, promoteRepositoryToNext, updateRepositoryText } from '@/api';
-import { Pencil, Check, X, Trash2, AlertCircle, ChevronDown, ChevronUp, Send } from 'lucide-react';
+import { archiveRepositories, deleteRepository, promoteRepositoryToNext, updateRepositoryText } from '@/api';
+import { Pencil, Check, X, Trash2, AlertCircle, Archive, ChevronDown, ChevronUp, Send } from 'lucide-react';
+import { describeArchiveFailure, isStaleArchiveFailure, summarizeArchiveResult } from '@/utils/archiveUtils';
 import { toast } from '../common/toast-config';
 import { ConfirmDialog } from '../common/confirm-dialog';
 import {
@@ -71,13 +72,16 @@ export function RepositoryTable({
   itemsPerPage,
   searchTerm,
   nextPostId,
-  onRepositoryUpdate
+  onRepositoryUpdate,
+  onRepositoryArchived
 }: RepositoryTableProps) {
   const [localRepositories, setLocalRepositories] = useState<Repository[]>(repositories);
   const [editingText, setEditingText] = useState<{ id: number; text: string } | null>(null);
   const [textInput, setTextInput] = useState('');
   const [textError, setTextError] = useState<string | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<Repository | null>(null);
+  const [showArchiveConfirm, setShowArchiveConfirm] = useState<Repository | null>(null);
+  const [archivingId, setArchivingId] = useState<number | null>(null);
   const [showPromoteConfirm, setShowPromoteConfirm] = useState<Repository | null>(null);
   const [promotingId, setPromotingId] = useState<number | null>(null);
   const textInputRef = useRef<HTMLTextAreaElement>(null);
@@ -191,6 +195,62 @@ export function RepositoryTable({
         ...toastOptions,
         id: 'content-alchemist-error'
       });
+    }
+  };
+
+  const handleArchiveRepository = async (repo: Repository) => {
+    if (archivingId !== null) return;
+
+    try {
+      setArchivingId(repo.id);
+      // Optimistic update - archiving moves the row out of the repositories table
+      setLocalRepositories(prevRepos =>
+        prevRepos.filter(r => r.id !== repo.id)
+      );
+
+      const result = await archiveRepositories({ ids: [repo.id] });
+      const { archivedCount, firstFailure } = summarizeArchiveResult(result);
+
+      if (archivedCount > 0) {
+        toast.success(`Repository archived successfully`, {
+          ...toastOptions,
+          id: `archive-${repo.id}`
+        });
+      } else if (firstFailure) {
+        // The row's posted flag can be stale, so put it back unless the server says it is already gone
+        if (!isStaleArchiveFailure(firstFailure)) {
+          setLocalRepositories(repositories);
+        }
+        toast.error(describeArchiveFailure(firstFailure), {
+          ...toastOptions,
+          id: `archive-error-${repo.id}`
+        });
+      } else {
+        // Nothing archived and nothing reported as failed - never treat that as success, or the row
+        // disappears as if it had been archived
+        setLocalRepositories(repositories);
+        toast.error(result.message || 'Failed to archive repository', {
+          ...toastOptions,
+          id: `archive-error-${repo.id}`
+        });
+      }
+
+      if (onRepositoryUpdate) {
+        await onRepositoryUpdate();
+      }
+      if (onRepositoryArchived) {
+        await onRepositoryArchived();
+      }
+    } catch (error) {
+      // Rollback on error
+      setLocalRepositories(repositories);
+      const message = error instanceof Error ? error.message : 'Failed to connect to Content Alchemist API';
+      toast.error(message, {
+        ...toastOptions,
+        id: 'content-alchemist-error'
+      });
+    } finally {
+      setArchivingId(null);
     }
   };
 
@@ -379,21 +439,44 @@ export function RepositoryTable({
                    <TooltipContent>Edit text</TooltipContent>
                  </Tooltip>
                </TooltipProvider>
-               <TooltipProvider>
-                 <Tooltip>
-                   <TooltipTrigger asChild>
-                     <Button
-                       variant="ghost"
-                       size="icon"
-                       onClick={() => setShowDeleteConfirm(repo)}
-                       className="h-8 w-8 text-muted-foreground hover:text-destructive"
-                     >
-                       <Trash2 className="h-4 w-4" />
-                     </Button>
-                   </TooltipTrigger>
-                   <TooltipContent>Delete repository</TooltipContent>
-                 </Tooltip>
-               </TooltipProvider>
+               {/* Only published repositories can be archived, so they get Archive instead of Delete */}
+               {repo.posted ? (
+                 <TooltipProvider>
+                   <Tooltip>
+                     <TooltipTrigger asChild>
+                       <span>
+                         <Button
+                           variant="ghost"
+                           size="icon"
+                           onClick={() => setShowArchiveConfirm(repo)}
+                           disabled={archivingId !== null}
+                           aria-label="Archive repository"
+                           className="h-8 w-8 text-muted-foreground hover:text-warning disabled:opacity-50"
+                         >
+                           <Archive className="h-4 w-4" />
+                         </Button>
+                       </span>
+                     </TooltipTrigger>
+                     <TooltipContent>Archive repository</TooltipContent>
+                   </Tooltip>
+                 </TooltipProvider>
+               ) : (
+                 <TooltipProvider>
+                   <Tooltip>
+                     <TooltipTrigger asChild>
+                       <Button
+                         variant="ghost"
+                         size="icon"
+                         onClick={() => setShowDeleteConfirm(repo)}
+                         className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                       >
+                         <Trash2 className="h-4 w-4" />
+                       </Button>
+                     </TooltipTrigger>
+                     <TooltipContent>Delete repository</TooltipContent>
+                   </Tooltip>
+                 </TooltipProvider>
+               )}
              </div>
            </div>
           )}
@@ -445,6 +528,22 @@ export function RepositoryTable({
           }
         }}
         onCancel={() => setShowDeleteConfirm(null)}
+      />
+
+      <ConfirmDialog
+        isOpen={showArchiveConfirm !== null}
+        title="Archive Repository"
+        message="Move this published repository to the archive? It will be removed from Posts and cannot be restored from the dashboard."
+        confirmText="Archive"
+        cancelText="Cancel"
+        variant="warning"
+        onConfirm={() => {
+          if (showArchiveConfirm) {
+            handleArchiveRepository(showArchiveConfirm);
+          }
+          setShowArchiveConfirm(null);
+        }}
+        onCancel={() => setShowArchiveConfirm(null)}
       />
 
       <ConfirmDialog

--- a/src/components/ui/layout/dashboard-content.tsx
+++ b/src/components/ui/layout/dashboard-content.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { OverviewCharts } from '../business/overview-charts';
 import { Card, CardContent } from '../layout/card';
 import { Clock, Server } from 'lucide-react';
@@ -9,6 +9,8 @@ import { CronJobs } from '../business/cron-jobs';
 import { ApiConfigs } from '../business/api-configs';
 import { CronJobHistory } from '../business/cron-job-history';
 import { RepositoryPreview } from '../business/repository-preview';
+import { ArchiveList } from '../business/archive-list';
+import { ArchiveOldRepositories } from '../business/archive-old-repositories';
 import { Tabs, TabsContent } from '../base/tabs';
 import { DashboardSidebar } from './dashboard-sidebar';
 import { MobileNavDrawer } from './mobile-nav-drawer';
@@ -19,6 +21,7 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import { useSwipeable } from 'react-swipeable';
 import { useSwipeableTabs } from '@/hooks/useSwipeableTabs';
 import type { Repository, RepositorySortBy, RepositorySortOrder } from '../../../types';
+import type { ArchiveFilterKey, ArchiveFilterState, ArchivedRepository } from '../../../types/archive';
 import type { CronJob, CronJobHistory as CronJobHistoryType } from '../../../api/index';
 import type { ManualGenerateResponse } from '../../../api';
 import { useApiConfigs } from '../../../hooks/useApiConfigs';
@@ -92,6 +95,21 @@ interface DashboardContentProps {
   isNavOpen: boolean;
   onNavOpen: () => void;
   onNavClose: () => void;
+  archiveItems: ArchivedRepository[];
+  archiveAll: number;
+  archiveLoading: boolean;
+  archiveFilters: ArchiveFilterState;
+  archiveShowFilters: boolean;
+  archiveCurrentPage: number;
+  archiveTotalPages: number;
+  archiveTotalItems: number;
+  archiveSetFilter: <K extends ArchiveFilterKey>(key: K, value: ArchiveFilterState[K]) => void;
+  archiveSetPage: (page: number) => void;
+  archiveResetFilters: () => void;
+  archiveToggleFilters: () => void;
+  fetchArchive: (forceFetch?: boolean) => Promise<void>;
+  refreshArchive: () => Promise<void>;
+  onArchiveMutation: () => Promise<void>;
 }
 
 export const DashboardContent = ({
@@ -136,7 +154,22 @@ export const DashboardContent = ({
   overviewLoading,
   isNavOpen,
   onNavOpen,
-  onNavClose
+  onNavClose,
+  archiveItems,
+  archiveAll,
+  archiveLoading,
+  archiveFilters,
+  archiveShowFilters,
+  archiveCurrentPage,
+  archiveTotalPages,
+  archiveTotalItems,
+  archiveSetFilter,
+  archiveSetPage,
+  archiveResetFilters,
+  archiveToggleFilters,
+  fetchArchive,
+  refreshArchive,
+  onArchiveMutation
 }: DashboardContentProps) => {
   const { activeTab, setActiveTab } = useTabPersistence('overview');
 
@@ -232,6 +265,22 @@ export const DashboardContent = ({
       fetchPreviews();
     }
   }, [activeTab, fetchPreviews]);
+
+  // Fetched once per session, on the first visit to either tab that shows archive numbers -
+  // lazily rather than at startup so cold start stays under the API rate limit.
+  // Gated on isApiReady: without credentials the API layer returns an empty stub that would be
+  // cached as a legitimately empty archive, and the ref would then block the refetch after the
+  // user saves their settings.
+  const archiveFetchedRef = useRef(false);
+  useEffect(() => {
+    if (!isApiReady) {
+      return;
+    }
+    if ((activeTab === 'archive' || activeTab === 'overview') && !archiveFetchedRef.current) {
+      archiveFetchedRef.current = true;
+      fetchArchive(false);
+    }
+  }, [activeTab, fetchArchive, isApiReady]);
 
   return (
     <div className="space-y-4 sm:space-y-6">
@@ -351,6 +400,7 @@ export const DashboardContent = ({
             <OverviewCharts
               posted={stats.posted}
               unposted={stats.unposted}
+              archived={archiveAll}
               statsLoading={statsLoading}
               cronJobs={cronJobs}
               cronJobsLoading={cronJobsLoading}
@@ -382,6 +432,31 @@ export const DashboardContent = ({
               totalItems={pagination.totalItems}
               loading={loading}
               isApiReady={isApiReady}
+              onRepositoryArchived={refreshArchive}
+            />
+          </TabsContent>
+
+          {/* Archive Tab */}
+          <TabsContent value="archive" className="mt-0 space-y-6">
+            <ArchiveOldRepositories
+              isApiReady={isApiReady}
+              onArchived={onArchiveMutation}
+            />
+
+            <ArchiveList
+              items={archiveItems}
+              all={archiveAll}
+              loading={archiveLoading}
+              isApiReady={isApiReady}
+              filters={archiveFilters}
+              showFilters={archiveShowFilters}
+              currentPage={archiveCurrentPage}
+              totalPages={archiveTotalPages}
+              totalItems={archiveTotalItems}
+              onFilterChange={archiveSetFilter}
+              onClearFilters={archiveResetFilters}
+              onToggleFilters={archiveToggleFilters}
+              onPageChange={archiveSetPage}
             />
           </TabsContent>
 

--- a/src/components/ui/layout/dashboard-layout.tsx
+++ b/src/components/ui/layout/dashboard-layout.tsx
@@ -31,7 +31,7 @@ export const DashboardLayout = ({
 
 
   const renderHeader = () => (
-    <div className="relative max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 mb-6">
+    <div className="relative w-full px-4 sm:px-6 lg:px-8 mb-6">
       <Card>
         <CardHeader className="py-3 sm:py-4 px-3 sm:px-4">
           <div className="flex items-center justify-between">
@@ -78,7 +78,7 @@ export const DashboardLayout = ({
   );
 
   const renderFooter = () => (
-    <div className="max-w-screen-2xl mx-auto px-3 sm:px-6 lg:px-8 mt-4 sm:mt-6">
+    <div className="w-full px-3 sm:px-6 lg:px-8 mt-4 sm:mt-6">
       <Card>
         <CardFooter className="p-3 sm:p-4 text-muted-foreground justify-center">
           <div className="text-center w-full text-sm">
@@ -108,7 +108,7 @@ export const DashboardLayout = ({
       <RefreshIndicator isRefreshing={isRefreshing} />
       <div className="py-3 sm:py-6">
         {renderHeader()}
-        <main className="max-w-screen-2xl mx-auto px-3 sm:px-6 lg:px-8 space-y-4 sm:space-y-6">
+        <main className="w-full px-3 sm:px-6 lg:px-8 space-y-4 sm:space-y-6">
           {children}
         </main>
         {renderFooter()}

--- a/src/config/nav-items.ts
+++ b/src/config/nav-items.ts
@@ -1,8 +1,9 @@
-import { Gauge, FolderGit2, Clock, Plug, Bot, type LucideIcon } from 'lucide-react';
+import { Gauge, FolderGit2, Archive, Clock, Plug, Bot, type LucideIcon } from 'lucide-react';
 
 export type DashboardTabKey =
   | 'overview'
   | 'repositories'
+  | 'archive'
   | 'automation'
   | 'integrations'
   | 'settings';
@@ -17,6 +18,7 @@ export interface NavItem {
 export const NAV_ITEMS = [
   { key: 'overview', label: 'Overview', shortLabel: 'Overview', icon: Gauge },
   { key: 'repositories', label: 'Repositories', shortLabel: 'Repos', icon: FolderGit2 },
+  { key: 'archive', label: 'Archive', shortLabel: 'Archive', icon: Archive },
   { key: 'automation', label: 'Cron', shortLabel: 'Cron', icon: Clock },
   { key: 'integrations', label: 'Integrations', shortLabel: 'APIs', icon: Plug },
   { key: 'settings', label: 'AI Settings', shortLabel: 'AI', icon: Bot },

--- a/src/hooks/useArchive.ts
+++ b/src/hooks/useArchive.ts
@@ -1,0 +1,274 @@
+import { useCallback, useRef, useState } from 'react';
+import { getArchivedRepositories } from '../api';
+import type { ArchiveFilterKey, ArchiveFilterState, ArchivedRepository } from '../types/archive';
+import {
+  DEFAULT_ARCHIVE_FILTERS,
+  DEFAULT_ARCHIVE_PAGE_SIZE,
+  buildArchiveRequestBody,
+  hasValidArchiveDateRanges,
+  normalizeArchiveSortBy,
+  normalizeArchiveSortOrder,
+} from '../utils/archiveUtils';
+import { getArchiveFromCache, saveArchiveToCache } from '../utils/cache-utils';
+import { getApiSettings, isApiConfigured } from '../utils/api-settings';
+import { useRepositoryLocalStorage } from './useRepositoryLocalStorage';
+
+const CACHE_KEY_STORAGE = 'cache_archive_key';
+
+/** Maps every filter field to the localStorage key that persists it. */
+const FILTER_STORAGE_KEYS = {
+  url: 'archiveUrlFilter',
+  text: 'archiveTextFilter',
+  dateAddedFrom: 'archiveDateAddedFrom',
+  dateAddedTo: 'archiveDateAddedTo',
+  datePostedFrom: 'archiveDatePostedFrom',
+  datePostedTo: 'archiveDatePostedTo',
+  dateArchivedFrom: 'archiveDateArchivedFrom',
+  dateArchivedTo: 'archiveDateArchivedTo',
+  sortBy: 'archiveSortBy',
+  sortOrder: 'archiveSortOrder',
+  pageSize: 'archivePageSize',
+} as const;
+
+interface ArchiveState {
+  items: ArchivedRepository[];
+  all: number;
+  loading: boolean;
+  stale: boolean;
+  newDataAvailable: boolean;
+  currentPage: number;
+  totalPages: number;
+  totalItems: number;
+  filters: ArchiveFilterState;
+  showFilters: boolean;
+}
+
+interface UseArchiveProps {
+  isCacheBust: boolean;
+  setErrorWithScroll: (errorMessage: string, toastId?: string) => void;
+}
+
+export const useArchive = ({ isCacheBust, setErrorWithScroll }: UseArchiveProps) => {
+  const { getStoredValue, setStoredValue } = useRepositoryLocalStorage();
+  const cachedResult = isCacheBust ? null : getArchiveFromCache();
+  const cached = cachedResult?.data;
+  const isFetching = useRef(false);
+  const latestRequestIdRef = useRef(0);
+
+  const [state, setState] = useState<ArchiveState>(() => {
+    const filters: ArchiveFilterState = {
+      url: getStoredValue('archiveUrlFilter', ''),
+      text: getStoredValue('archiveTextFilter', ''),
+      dateAddedFrom: getStoredValue('archiveDateAddedFrom', ''),
+      dateAddedTo: getStoredValue('archiveDateAddedTo', ''),
+      datePostedFrom: getStoredValue('archiveDatePostedFrom', ''),
+      datePostedTo: getStoredValue('archiveDatePostedTo', ''),
+      dateArchivedFrom: getStoredValue('archiveDateArchivedFrom', ''),
+      dateArchivedTo: getStoredValue('archiveDateArchivedTo', ''),
+      sortBy: normalizeArchiveSortBy(getStoredValue('archiveSortBy', DEFAULT_ARCHIVE_FILTERS.sortBy)),
+      sortOrder: normalizeArchiveSortOrder(getStoredValue('archiveSortOrder', DEFAULT_ARCHIVE_FILTERS.sortOrder)),
+      pageSize: getStoredValue('archivePageSize', DEFAULT_ARCHIVE_PAGE_SIZE),
+    };
+
+    return {
+      items: cached?.items || [],
+      all: cached?.all || 0,
+      loading: !cached || cached.items.length === 0,
+      stale: cachedResult?.isStale || false,
+      newDataAvailable: false,
+      currentPage: cached?.pagination.currentPage || 1,
+      totalPages: cached?.pagination.totalPages || 1,
+      totalItems: cached?.pagination.totalItems || 0,
+      filters,
+      showFilters: getStoredValue('archiveShowFilters', false),
+    };
+  });
+
+  const fetchArchive = useCallback(async (
+    forceFetch: boolean = false,
+    overrides?: Partial<ArchiveFilterState> & { page?: number }
+  ) => {
+    if (isFetching.current && !forceFetch) {
+      return;
+    }
+
+    const effectiveFilters: ArchiveFilterState = { ...state.filters, ...overrides };
+    const effectivePage = overrides?.page ?? state.currentPage;
+
+    // Bail out before claiming the request id: an inverted range sends no request, and bumping the
+    // id here would strand an in-flight fetch (its finally block would skip clearing isFetching).
+    // loading is cleared explicitly - the filter panel shows the range error instead.
+    if (!hasValidArchiveDateRanges(effectiveFilters)) {
+      setState(prev => (prev.loading ? { ...prev, loading: false } : prev));
+      return;
+    }
+
+    const requestId = latestRequestIdRef.current + 1;
+    latestRequestIdRef.current = requestId;
+
+    const textLanguage = getApiSettings().displayLanguage || undefined;
+    const requestBody = buildArchiveRequestBody(effectiveFilters, effectivePage, textLanguage);
+    const cacheKey = JSON.stringify(requestBody);
+
+    const cacheResult = getArchiveFromCache();
+    const hasCache = cacheResult?.data !== undefined;
+    const storedCacheKey = localStorage.getItem(CACHE_KEY_STORAGE);
+    const isBackgroundFetch = hasCache && storedCacheKey === cacheKey && !forceFetch;
+
+    try {
+      isFetching.current = true;
+
+      if (!isBackgroundFetch) {
+        setState(prev => ({ ...prev, loading: true }));
+      }
+
+      const response = await getArchivedRepositories(requestBody);
+
+      if (requestId !== latestRequestIdRef.current) {
+        return;
+      }
+
+      if (!response?.data?.items) {
+        throw new Error(response?.message || 'Invalid response format');
+      }
+
+      const { data } = response;
+      // With pagination disabled ("All") the server echoes page 0 / total_pages 1 - normalize it for the UI
+      const pagination = effectiveFilters.pageSize > 0
+        ? {
+            currentPage: data.page || effectivePage,
+            pageSize: data.page_size,
+            totalPages: data.total_pages || 1,
+            totalItems: data.total_items,
+          }
+        : {
+            currentPage: 1,
+            pageSize: 0,
+            totalPages: 1,
+            totalItems: data.total_items || data.items.length,
+          };
+
+      localStorage.setItem(CACHE_KEY_STORAGE, cacheKey);
+
+      const cachePayload = {
+        items: data.items,
+        all: data.all,
+        pagination,
+        timestamp: Date.now(),
+      };
+
+      // Under cache_bust the deferred newDataAvailable path is skipped entirely: applyNewData reads
+      // from the cache, which is not written in that mode, so it would push stale rows back in.
+      if (isBackgroundFetch && cacheResult?.data && !isCacheBust) {
+        const hasChanges = JSON.stringify(data.items) !== JSON.stringify(cacheResult.data.items);
+
+        if (hasChanges) {
+          saveArchiveToCache(cachePayload);
+          setState(prev => ({ ...prev, newDataAvailable: true, stale: false }));
+        } else {
+          setState(prev => ({ ...prev, stale: false }));
+        }
+        return;
+      }
+
+      saveArchiveToCache(cachePayload);
+      setState(prev => ({
+        ...prev,
+        items: data.items,
+        all: data.all,
+        currentPage: pagination.currentPage,
+        totalPages: pagination.totalPages,
+        totalItems: pagination.totalItems,
+        stale: false,
+      }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+
+      if (message.includes('Rate limit exceeded')) {
+        console.warn('[useArchive] Rate limit exceeded. Please try again later.');
+        return;
+      }
+
+      if (isBackgroundFetch) {
+        setState(prev => ({ ...prev, stale: true }));
+        return;
+      }
+
+      if (isApiConfigured()) {
+        setErrorWithScroll(`Failed to fetch archived repositories: ${message}`, 'archive-error');
+      }
+    } finally {
+      if (requestId === latestRequestIdRef.current) {
+        isFetching.current = false;
+        setState(prev => ({ ...prev, loading: false }));
+      }
+    }
+  }, [state.filters, state.currentPage, isCacheBust, setErrorWithScroll]);
+
+  const setFilter = useCallback(<K extends ArchiveFilterKey>(key: K, value: ArchiveFilterState[K]) => {
+    setStoredValue(FILTER_STORAGE_KEYS[key], value);
+    setState(prev => ({ ...prev, filters: { ...prev.filters, [key]: value }, currentPage: 1 }));
+    fetchArchive(true, { [key]: value, page: 1 } as Partial<ArchiveFilterState> & { page: number });
+  }, [fetchArchive, setStoredValue]);
+
+  const setPage = useCallback((page: number) => {
+    setState(prev => ({ ...prev, currentPage: page }));
+    fetchArchive(true, { page });
+  }, [fetchArchive]);
+
+  const resetFilters = useCallback(() => {
+    (Object.keys(FILTER_STORAGE_KEYS) as ArchiveFilterKey[]).forEach(key => {
+      setStoredValue(FILTER_STORAGE_KEYS[key], DEFAULT_ARCHIVE_FILTERS[key]);
+    });
+    setState(prev => ({ ...prev, filters: { ...DEFAULT_ARCHIVE_FILTERS }, currentPage: 1 }));
+    fetchArchive(true, { ...DEFAULT_ARCHIVE_FILTERS, page: 1 });
+  }, [fetchArchive, setStoredValue]);
+
+  const toggleFilters = useCallback(() => {
+    setState(prev => {
+      const showFilters = !prev.showFilters;
+      setStoredValue('archiveShowFilters', showFilters);
+      return { ...prev, showFilters };
+    });
+  }, [setStoredValue]);
+
+  const refreshArchive = useCallback(async () => {
+    await fetchArchive(true);
+  }, [fetchArchive]);
+
+  const applyNewData = useCallback(() => {
+    const cacheResult = getArchiveFromCache();
+    if (!cacheResult?.data) return;
+
+    const { data } = cacheResult;
+    setState(prev => ({
+      ...prev,
+      items: data.items,
+      all: data.all,
+      currentPage: data.pagination.currentPage,
+      totalPages: data.pagination.totalPages,
+      totalItems: data.pagination.totalItems,
+      newDataAvailable: false,
+    }));
+  }, []);
+
+  return {
+    items: state.items,
+    all: state.all,
+    loading: state.loading,
+    stale: state.stale,
+    newDataAvailable: state.newDataAvailable,
+    currentPage: state.currentPage,
+    totalPages: state.totalPages,
+    totalItems: state.totalItems,
+    filters: state.filters,
+    showFilters: state.showFilters,
+    fetchArchive,
+    setFilter,
+    setPage,
+    resetFilters,
+    toggleFilters,
+    refreshArchive,
+    applyNewData,
+  };
+};

--- a/src/hooks/useRepositoryLocalStorage.ts
+++ b/src/hooks/useRepositoryLocalStorage.ts
@@ -15,7 +15,20 @@ export type RepositoryStorageKey =
   | 'dashboardSortBy'
   | 'dashboardSortOrder'
   | 'dashboardItemsPerPage'
-  | 'postsShowFilters';
+  | 'postsShowFilters'
+  | 'archiveUrlFilter'
+  | 'archiveTextFilter'
+  | 'archiveDateAddedFrom'
+  | 'archiveDateAddedTo'
+  | 'archiveDatePostedFrom'
+  | 'archiveDatePostedTo'
+  | 'archiveDateArchivedFrom'
+  | 'archiveDateArchivedTo'
+  | 'archiveSortBy'
+  | 'archiveSortOrder'
+  | 'archivePageSize'
+  | 'archiveShowFilters'
+  | 'archiveOlderThanDays';
 
 export function useRepositoryLocalStorage() {
   const getStoredValue = useCallback(<T>(key: RepositoryStorageKey, defaultValue: T): T => {

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,10 @@
 
 @layer base {
   :root {
+    /* Makes native scrollbars - the page's and any inner scroll box - render in the
+       current theme, so they all look the same instead of light-on-dark */
+    color-scheme: light;
+
     /* Core colors */
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
@@ -66,6 +70,9 @@
   }
 
   .dark {
+    /* Dark native scrollbars, page-level and inside any scroll box */
+    color-scheme: dark;
+
     /* Core colors */
     --background: 220 13% 9%;
     --foreground: 210 40% 98%;

--- a/src/types/archive.ts
+++ b/src/types/archive.ts
@@ -1,0 +1,137 @@
+export type ArchiveSortBy = 'date_archived' | 'date_posted' | 'date_added' | 'id';
+
+// Note: the archive endpoints expect lowercase sort order, unlike RepositorySortOrder ('ASC' | 'DESC')
+export type ArchiveSortOrder = 'asc' | 'desc';
+
+/** A row of the archived_repositories table. `id` is the archive row id, `original_id` the repository id. */
+export interface ArchivedRepository {
+  id: number;
+  original_id?: number | null;
+  url: string;
+  text: string;
+  date_added?: string | null;
+  date_posted?: string | null;
+  date_archived: string;
+}
+
+/** An entry of `data.archived` returned by the archive mutations. In dry-run mode `archive_id` is 0 and `date_archived` is null. */
+export interface ArchiveOperationItem {
+  archive_id: number;
+  id?: number | null;
+  url: string;
+  date_added?: string | null;
+  date_posted?: string | null;
+  date_archived?: string | null;
+}
+
+export type ArchiveFailureReason = 'already_processed' | 'not_found' | 'not_posted' | (string & {});
+
+export interface ArchiveFailure {
+  identifier: string;
+  reason: ArchiveFailureReason;
+  message: string;
+}
+
+export interface ArchiveRepositoryResponse {
+  status: string;
+  message: string;
+  data: {
+    archived: ArchiveOperationItem[];
+    failed: ArchiveFailure[];
+  };
+}
+
+export interface ArchiveOldRepositoriesResponse {
+  status: string;
+  message: string;
+  data: {
+    archived_count: number;
+    dry_run: boolean;
+    archived: ArchiveOperationItem[];
+  };
+}
+
+/** Body of POST /get-archived-repositories/. `limit` is intentionally absent - see buildArchiveRequestBody. */
+export interface GetArchivedRepositoriesRequest {
+  page?: number;
+  page_size?: number;
+  sort_by?: ArchiveSortBy;
+  sort_order?: ArchiveSortOrder;
+  url?: string;
+  text?: string;
+  date_added_from?: string;
+  date_added_to?: string;
+  date_posted_from?: string;
+  date_posted_to?: string;
+  date_archived_from?: string;
+  date_archived_to?: string;
+  text_language?: string;
+}
+
+export interface GetArchivedRepositoriesResponse {
+  status: string;
+  message: string;
+  data: {
+    all: number;
+    items: ArchivedRepository[];
+    page: number;
+    page_size: number;
+    total_pages: number;
+    total_items: number;
+  };
+}
+
+export interface ArchiveFilterState {
+  url: string;
+  text: string;
+  dateAddedFrom: string;
+  dateAddedTo: string;
+  datePostedFrom: string;
+  datePostedTo: string;
+  dateArchivedFrom: string;
+  dateArchivedTo: string;
+  sortBy: ArchiveSortBy;
+  sortOrder: ArchiveSortOrder;
+  pageSize: number;
+}
+
+export type ArchiveFilterKey = keyof ArchiveFilterState;
+
+export interface ArchiveFiltersProps {
+  filters: ArchiveFilterState;
+  loading: boolean;
+  onFilterChange: <K extends ArchiveFilterKey>(key: K, value: ArchiveFilterState[K]) => void;
+  onClearFilters: () => void;
+}
+
+export interface ArchiveTableProps {
+  items: ArchivedRepository[];
+  loading: boolean;
+  isApiReady: boolean;
+  totalItems: number;
+  itemsPerPage: number;
+  hasFilters: boolean;
+}
+
+export type ArchiveMobileViewProps = ArchiveTableProps;
+
+export interface ArchiveListProps {
+  items: ArchivedRepository[];
+  all: number;
+  loading: boolean;
+  isApiReady: boolean;
+  filters: ArchiveFilterState;
+  showFilters: boolean;
+  currentPage: number;
+  totalPages: number;
+  totalItems: number;
+  onFilterChange: <K extends ArchiveFilterKey>(key: K, value: ArchiveFilterState[K]) => void;
+  onClearFilters: () => void;
+  onToggleFilters: () => void;
+  onPageChange: (page: number) => void;
+}
+
+export interface ArchiveOldRepositoriesProps {
+  isApiReady: boolean;
+  onArchived: () => void | Promise<void>;
+}

--- a/src/types/repositoryList.ts
+++ b/src/types/repositoryList.ts
@@ -31,6 +31,7 @@ export interface RepositoryTableProps {
   searchTerm: string;
   nextPostId?: number;
   onRepositoryUpdate?: () => void | Promise<void>;
+  onRepositoryArchived?: () => void | Promise<void>;
 }
 
 export interface RepositoryMobileViewProps {
@@ -42,6 +43,7 @@ export interface RepositoryMobileViewProps {
   searchTerm: string;
   nextPostId?: number;
   onRepositoryUpdate?: () => void | Promise<void>;
+  onRepositoryArchived?: () => void | Promise<void>;
 }
 
 export interface RepositoryPaginationProps {

--- a/src/utils/archiveUtils.ts
+++ b/src/utils/archiveUtils.ts
@@ -1,0 +1,173 @@
+import type {
+  ArchiveFailure,
+  ArchiveFilterState,
+  ArchiveRepositoryResponse,
+  ArchiveSortBy,
+  ArchiveSortOrder,
+  GetArchivedRepositoriesRequest,
+} from '../types/archive';
+
+export const DEFAULT_ARCHIVE_SORT_BY: ArchiveSortBy = 'date_archived';
+export const DEFAULT_ARCHIVE_SORT_ORDER: ArchiveSortOrder = 'desc';
+export const DEFAULT_ARCHIVE_PAGE_SIZE = 10;
+export const DEFAULT_ARCHIVE_DAYS = 30;
+
+/** The API rejects more than 100 identifiers per archive request. */
+export const ARCHIVE_MAX_IDENTIFIERS = 100;
+
+export const ARCHIVE_SORT_BY_OPTIONS: ArchiveSortBy[] = ['date_archived', 'date_posted', 'date_added', 'id'];
+
+export const ARCHIVE_SORT_BY_LABELS: Record<ArchiveSortBy, string> = {
+  date_archived: 'Date Archived',
+  date_posted: 'Date Posted',
+  date_added: 'Date Added',
+  id: 'ID',
+};
+
+export const isArchiveSortBy = (value: string | null | undefined): value is ArchiveSortBy => {
+  return ARCHIVE_SORT_BY_OPTIONS.includes(value as ArchiveSortBy);
+};
+
+export const normalizeArchiveSortBy = (value: string | null | undefined): ArchiveSortBy => {
+  return isArchiveSortBy(value) ? value : DEFAULT_ARCHIVE_SORT_BY;
+};
+
+export const normalizeArchiveSortOrder = (value: string | null | undefined): ArchiveSortOrder => {
+  return value === 'asc' || value === 'desc' ? value : DEFAULT_ARCHIVE_SORT_ORDER;
+};
+
+export const DEFAULT_ARCHIVE_FILTERS: ArchiveFilterState = {
+  url: '',
+  text: '',
+  dateAddedFrom: '',
+  dateAddedTo: '',
+  datePostedFrom: '',
+  datePostedTo: '',
+  dateArchivedFrom: '',
+  dateArchivedTo: '',
+  sortBy: DEFAULT_ARCHIVE_SORT_BY,
+  sortOrder: DEFAULT_ARCHIVE_SORT_ORDER,
+  pageSize: DEFAULT_ARCHIVE_PAGE_SIZE,
+};
+
+/** `from` must not be later than `to`; an empty bound is always valid. */
+export const isValidDateRange = (from: string, to: string): boolean => {
+  if (!from || !to) return true;
+  return from <= to;
+};
+
+export const ARCHIVE_DATE_RANGE_KEYS: Array<[keyof ArchiveFilterState, keyof ArchiveFilterState]> = [
+  ['dateAddedFrom', 'dateAddedTo'],
+  ['datePostedFrom', 'datePostedTo'],
+  ['dateArchivedFrom', 'dateArchivedTo'],
+];
+
+export const hasValidArchiveDateRanges = (filters: ArchiveFilterState): boolean => {
+  return ARCHIVE_DATE_RANGE_KEYS.every(([from, to]) =>
+    isValidDateRange(filters[from] as string, filters[to] as string)
+  );
+};
+
+const ARCHIVE_FILTER_FLAGS = (filters: ArchiveFilterState, defaultPageSize: number): boolean[] => [
+  !!filters.url,
+  !!filters.text,
+  !!filters.dateAddedFrom,
+  !!filters.dateAddedTo,
+  !!filters.datePostedFrom,
+  !!filters.datePostedTo,
+  !!filters.dateArchivedFrom,
+  !!filters.dateArchivedTo,
+  filters.sortBy !== DEFAULT_ARCHIVE_SORT_BY,
+  filters.sortOrder !== DEFAULT_ARCHIVE_SORT_ORDER,
+  filters.pageSize !== defaultPageSize,
+];
+
+export const hasActiveArchiveFilters = (
+  filters: ArchiveFilterState,
+  defaultPageSize: number = DEFAULT_ARCHIVE_PAGE_SIZE
+): boolean => {
+  return ARCHIVE_FILTER_FLAGS(filters, defaultPageSize).some(Boolean);
+};
+
+export const countActiveArchiveFilters = (
+  filters: ArchiveFilterState,
+  defaultPageSize: number = DEFAULT_ARCHIVE_PAGE_SIZE
+): number => {
+  return ARCHIVE_FILTER_FLAGS(filters, defaultPageSize).filter(Boolean).length;
+};
+
+/**
+ * Builds the POST /get-archived-repositories/ body from the UI filter state.
+ *
+ * Two API quirks are handled here:
+ * - `limit` is never sent: the server uses it as the effective page size whenever it is > 0,
+ *   which would silently override `page_size`.
+ * - pageSize 0 ("All") sends neither `page` nor `page_size`, because any positive `page`
+ *   activates pagination - with `page_size: 0` that yields an empty window.
+ *
+ * Dates are passed through as YYYY-MM-DD; the server treats a date-only `*_to` bound as
+ * end-of-day. That bound is evaluated in server time while formatDate renders in the
+ * user's configured timezone, so a row near midnight may look just outside the range.
+ */
+export const buildArchiveRequestBody = (
+  filters: ArchiveFilterState,
+  page: number,
+  textLanguage?: string
+): GetArchivedRepositoriesRequest => {
+  const body: GetArchivedRepositoriesRequest = {
+    sort_by: filters.sortBy,
+    sort_order: filters.sortOrder,
+  };
+
+  if (filters.pageSize > 0) {
+    body.page = Math.max(1, page);
+    body.page_size = filters.pageSize;
+  }
+
+  const optional: Array<[keyof GetArchivedRepositoriesRequest, string]> = [
+    ['url', filters.url],
+    ['text', filters.text],
+    ['date_added_from', filters.dateAddedFrom],
+    ['date_added_to', filters.dateAddedTo],
+    ['date_posted_from', filters.datePostedFrom],
+    ['date_posted_to', filters.datePostedTo],
+    ['date_archived_from', filters.dateArchivedFrom],
+    ['date_archived_to', filters.dateArchivedTo],
+    ['text_language', textLanguage || ''],
+  ];
+
+  optional.forEach(([key, value]) => {
+    const trimmed = value.trim();
+    if (trimmed) {
+      (body as Record<string, unknown>)[key] = trimmed;
+    }
+  });
+
+  return body;
+};
+
+const ARCHIVE_FAILURE_MESSAGES: Record<string, string> = {
+  already_processed: 'Duplicate identifier in the same request',
+  not_found: 'Repository not found',
+  not_posted: 'Only published repositories can be archived',
+};
+
+export const describeArchiveFailure = (failure: ArchiveFailure): string => {
+  return ARCHIVE_FAILURE_MESSAGES[failure.reason] || failure.message || 'Failed to archive repository';
+};
+
+/** `not_found` / `already_processed` mean the row is gone server-side, so the list should still be refreshed. */
+export const isStaleArchiveFailure = (failure: ArchiveFailure): boolean => {
+  return failure.reason === 'not_found' || failure.reason === 'already_processed';
+};
+
+export const summarizeArchiveResult = (response: ArchiveRepositoryResponse) => {
+  const archived = response.data?.archived || [];
+  const failed = response.data?.failed || [];
+
+  return {
+    archivedCount: archived.length,
+    failedCount: failed.length,
+    firstFailure: failed[0],
+  };
+};

--- a/src/utils/cache-utils.ts
+++ b/src/utils/cache-utils.ts
@@ -1,10 +1,24 @@
 import type { Repository } from '../types';
+import type { ArchivedRepository } from '../types/archive';
 import type { CronJob, CronJobHistory } from '../api/index';
 import type { ApiConfig } from '../api/api-configs';
 
 interface RepositoriesCache {
   repositories: Repository[];
   stats: { all: number; posted: number; unposted: number };
+  pagination: {
+    currentPage: number;
+    pageSize: number;
+    totalPages: number;
+    totalItems: number;
+  };
+  timestamp: number;
+}
+
+// Kept separate from RepositoriesCache: archived rows have a different shape and no posted/unposted stats
+interface ArchiveCache {
+  items: ArchivedRepository[];
+  all: number;
   pagination: {
     currentPage: number;
     pageSize: number;
@@ -77,6 +91,30 @@ export const getRepositoriesFromCache = (): CacheResult<RepositoriesCache> | nul
     const data = JSON.parse(cachedData) as RepositoriesCache;
     const isStale = Date.now() - data.timestamp > CACHE_EXPIRY;
     
+    return {
+      data,
+      isStale
+    };
+  } catch {
+    return null;
+  }
+};
+
+export const saveArchiveToCache = (data: ArchiveCache) => {
+  localStorage.setItem('cache_archive', JSON.stringify({
+    ...data,
+    timestamp: Date.now()
+  }));
+};
+
+export const getArchiveFromCache = (): CacheResult<ArchiveCache> | null => {
+  const cachedData = localStorage.getItem('cache_archive');
+  if (!cachedData) return null;
+
+  try {
+    const data = JSON.parse(cachedData) as ArchiveCache;
+    const isStale = Date.now() - data.timestamp > CACHE_EXPIRY;
+
     return {
       data,
       isStale
@@ -218,6 +256,7 @@ export const clearAllCaches = () => {
   const clearedCaches: string[] = [];
   const cacheKeys = [
     'cache_repositories',
+    'cache_archive',
     'cache_previews',
     'cache_cron_jobs',
     'cache_cron_job_history',

--- a/src/utils/date-format.ts
+++ b/src/utils/date-format.ts
@@ -1,6 +1,32 @@
 import { getApiSettings } from "./api-settings";
 import { normalizeTimezoneForIntl } from "./timezone-mapper";
 
+/**
+ * Intl.DateTimeFormat construction is expensive and this runs once per rendered date cell -
+ * hundreds of times for a long table. Instances are reused per timezone/hour-format pair; the
+ * settings themselves are still read on every call, so a settings change takes effect immediately.
+ */
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getDateTimeFormatter(timeZone: string, hour12: boolean): Intl.DateTimeFormat {
+  const key = `${timeZone}|${hour12}`;
+  const cached = formatterCache.get(key);
+  if (cached) return cached;
+
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12,
+  });
+  formatterCache.set(key, formatter);
+  return formatter;
+}
+
 export function formatDate(dateString: string): string {
   const settings = getApiSettings();
   const dateFormat = settings.dateFormat || "DD.MM.YYYY HH:mm:ss";
@@ -8,20 +34,9 @@ export function formatDate(dateString: string): string {
   const timezone = settings.timezone || "Europe/Kyiv";
   const normalizedTimezone = normalizeTimezoneForIntl(timezone);
 
-  const options: Intl.DateTimeFormatOptions = {
-    timeZone: normalizedTimezone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: is12HourFormat,
-  };
-
   try {
     const date = new Date(dateString);
-    const formatter = new Intl.DateTimeFormat("en-US", options);
+    const formatter = getDateTimeFormatter(normalizedTimezone, is12HourFormat);
     const parts = formatter.formatToParts(date);
     const values: { [key: string]: string } = {};
 


### PR DESCRIPTION
## What this is

A new **Archive** section in the dashboard plus an archive action in the Posts table. The UI covers all three archive endpoints of `content-alchemist` (`API.md`) — there are no others: no unarchive, no delete-from-archive.

| Endpoint | Where in the UI |
|---|---|
| `POST /archive-repository/` | Archive button in a Posts row (replaces Delete on published rows — the API only accepts published repositories) |
| `POST /archive-old-repositories/` | "Archive Old Posts" card: days field + Preview via `dry_run`, then the real run |
| `POST /get-archived-repositories/` | "Archived" table: Url/Text filters, all three date ranges, `sort_by`/`sort_order`, page size, pagination |

## Decisions worth knowing when reviewing

- **Delete is gone for published repositories** — Archive took its place. A published repository can no longer be deleted from the UI, only archived. This is intentional.
- **The 5 req/min limit is shared across all alchemist endpoints**, so the archive is fetched lazily (first visit to Overview or Archive), stays out of the `useCache` sweep and the `useDataRefresh` fan-out, and after a bulk run only the archive and Posts are refreshed — not the previews.
- **`limit` is never sent to `get-archived-repositories`** — the server uses it as the effective page size and would silently override `page_size`. For "All", neither `page` nor `page_size` is sent.
- **401 and 429 come back as plain text**, not JSON, so archive requests go through a dedicated parser: `response.json()` would throw a `SyntaxError` and mask the real status.
- **The preview does not disappear** while the days field is edited — it dims and is marked stale, and Archive stays disabled until the preview is refreshed. The same invariant is duplicated in the handler.
- The archive column is **Archive ID** (the `id` of the `archived_repositories` row), not `original_id`: archiving deletes the original row, so that id points at nothing.

## Incidental fixes

The second and third commits touch shared code, so they affect the whole app:

- `Button`: no variant carries a real border any more; the outline edge is drawn with an inset shadow. A border participates in layout and rounds differently from a filled box, which made outline buttons look shorter than the filled ones next to them (visible on Cancel/Save in settings too).
- `index.css`: `color-scheme` is now declared per theme — without it the browser painted native scrollbars light, so any inner scroll box looked nothing like the page's own scrollbar.
- `dashboard-layout`: dropped `max-w-screen-2xl` — content now uses the full width.
- `formatDate`: `Intl.DateTimeFormat` is no longer constructed for every date cell. This speeds up every table, not just the archive one.

## Verification

`npx tsc --noEmit` is clean, `npm run build` passes. The live API paths were exercised manually in the browser by the author of these changes (archiving a single repository, preview and bulk run over 900+ records, filters and pagination).

Separately: `npx eslint` does not run at all in this repository — `eslint-plugin-react-hooks` is incompatible with ESLint 10 (`context.getSourceCode is not a function`). Unrelated to these changes, but linting is currently broken here.
