### PR TITLE
fix(ui): honour iOS safe areas in the mobile bottom nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- viewport-fit=cover is what makes env(safe-area-inset-*) resolve to real
+         values; without it they are always 0 and every safe-area rule in
+         index.css is dead code. Required because the manifest is
+         display:standalone, so an installed instance draws under the rounded
+         corners and the home indicator.
+         No maximum-scale / user-scalable=no here - that breaks pinch-zoom for
+         everyone (WCAG 1.4.4). The iOS focus-zoom fix is the 16px field floor
+         in index.css. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#ffffff" />
     <title>Dashboard</title>

--- a/src/components/ui/common/refresh-indicator.tsx
+++ b/src/components/ui/common/refresh-indicator.tsx
@@ -13,7 +13,10 @@ const RefreshIndicator: React.FC<RefreshIndicatorProps> = ({
   return (
     <div
       className={cn(
-        'fixed top-0 left-0 right-0 z-50 h-1 bg-transparent transition-all duration-300 pointer-events-none',
+        // `top` follows the safe-area inset, not 0: with viewport-fit=cover an
+        // installed instance draws under the status bar, which would swallow this
+        // 1px bar entirely. Body padding cannot do it - the element is fixed.
+        'fixed top-[env(safe-area-inset-top,0px)] left-0 right-0 z-50 h-1 bg-transparent transition-all duration-300 pointer-events-none',
         isRefreshing ? 'opacity-100' : 'opacity-0',
         className
       )}

--- a/src/components/ui/layout/dashboard-bottom-nav.tsx
+++ b/src/components/ui/layout/dashboard-bottom-nav.tsx
@@ -19,12 +19,14 @@ interface DashboardBottomNavProps {
  * plus `aria-current` keep the desktop nav byte-identical and the a11y tree
  * unambiguous; Radix's roving tabindex buys nothing on a touch device.
  *
- * Six equal `flex-1` slots: 320px / 6 = 53px wide and ~52px tall, both clear the
- * 44px minimum touch target, so all six destinations stay visible - no overflow
- * menu and no scroll strip, which would reintroduce the drawer's discoverability
+ * Six equal `flex-1` slots inside the bar's safe-area padding: (320 - 32) / 6 =
+ * 48px wide and ~52px tall at the narrowest supported width, both clear the 44px
+ * minimum touch target, so all six destinations stay visible - no overflow menu
+ * and no scroll strip, which would reintroduce the drawer's discoverability
  * problem. `shortLabel` exists in nav-items.ts for exactly this. Bar height is
  * owned by `--bottom-nav-h` in index.css so page padding and toast offsets can
- * read it.
+ * read it, and the insets by `.bottom-nav-insets` - see the note there for why
+ * the horizontal floor is not just `env()`.
  */
 export const DashboardBottomNav = ({
   activeTab,
@@ -33,7 +35,7 @@ export const DashboardBottomNav = ({
 }: DashboardBottomNavProps) => (
   <nav
     aria-label="Main navigation"
-    className="md:hidden fixed inset-x-0 bottom-0 z-40 flex h-[var(--bottom-nav-h)] items-stretch border-t border-border bg-background/95 pb-[env(safe-area-inset-bottom,0px)] backdrop-blur supports-[backdrop-filter]:bg-background/80"
+    className="bottom-nav-insets md:hidden fixed inset-x-0 bottom-0 z-40 flex h-[var(--bottom-nav-h)] items-stretch border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80"
   >
     {NAV_ITEMS.map((item) => {
       const Icon = item.icon;

--- a/src/index.css
+++ b/src/index.css
@@ -139,6 +139,16 @@
   body {
     @apply bg-background text-foreground;
     font-feature-settings: "rlig" 1, "calt" 1;
+
+    /* index.html sets viewport-fit=cover, so the page now draws under the notch,
+       the rounded corners and the status bar. Keep normal flow content out of
+       those areas. The bottom is deliberately absent: the fixed bottom nav owns
+       it via --bottom-nav-h, and body padding would not affect a fixed element
+       anyway. All four insets are 0 on hardware without them, so this is inert
+       on desktop and on older phones. */
+    padding-top: env(safe-area-inset-top, 0px);
+    padding-left: env(safe-area-inset-left, 0px);
+    padding-right: env(safe-area-inset-right, 0px);
   }
 
   /* Height of the mobile bottom nav, declared once and read by everything that
@@ -185,6 +195,25 @@
 }
 
 @layer components {
+  /* Safe-area insets for the fixed mobile bottom nav. Its border and background
+     still span the full width - only the buttons are inset.
+
+     The horizontal floor is the point: on iPhone in PORTRAIT both left and right
+     insets are 0, yet the display's rounded corners still clip the outermost
+     slots, which is what hid the first and last icons. So the floor handles
+     portrait and env() handles landscape, where the inset is real (~44px).
+
+     Bottom needs no floor: with viewport-fit=cover the inset is the home
+     indicator's own height on the devices that have one, and 0 on those that
+     don't - a hardcoded floor would just add dead space on the latter. It pairs
+     with --bottom-nav-h, which adds the same inset to the height, so the content
+     box stays exactly 3.25rem. */
+  .bottom-nav-insets {
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    padding-left: max(env(safe-area-inset-left, 0px), 1rem);
+    padding-right: max(env(safe-area-inset-right, 0px), 1rem);
+  }
+
   /* Card improvements */
   .card-enhanced {
     @apply bg-card text-card-foreground shadow-sm border border-border rounded-lg;


### PR DESCRIPTION
Fixes both symptoms reported on device: the first and last nav icons clipped by the display's rounded corners, and the home indicator sitting on top of the icon row.

## Root cause

`index.html` had no `viewport-fit=cover`, so **every `env(safe-area-inset-*)` in the app resolved to 0**. The `env(safe-area-inset-bottom)` already baked into `--bottom-nav-h` and into the bar's padding in #9 was dead code from the day it was written — it looked right in review and did nothing.

This matters here specifically because `public/manifest.json` is `"display": "standalone"`. An installed instance draws under the rounded corners and the home indicator, with nothing holding it off.

## The patch

- **`viewport-fit=cover`** on the viewport meta — the thing that makes insets resolve at all. Still no `maximum-scale` / `user-scalable=no`: that breaks pinch-zoom for everyone (WCAG 1.4.4), and the iOS focus-zoom fix stays the 16px field floor from #9.
- Because the page now goes edge to edge, **`body` takes the top/left/right insets**, keeping the header and content out of the status bar and the notch. Bottom is left to the fixed nav — body padding cannot affect a fixed element anyway.
- **`.bottom-nav-insets`** gives the bar its own insets. The horizontal value is `max(env(...), 1rem)`, not plain `env(...)`, and that is the actual fix for the corner clipping: **in portrait both side insets are 0 on iPhone**, yet the rounded corners still clip the outermost slots. The floor covers portrait, `env()` covers landscape (~44px). Bottom gets no floor — it is the home indicator's real height where one exists and 0 elsewhere, and a hardcoded floor would only add dead space on devices without one.
- The **refresh indicator** is `position: fixed`, so body padding cannot move it; its `top` follows the inset directly, or the status bar would swallow the 1px bar.

## Verification

Measured in Chrome with the sized-iframe harness, then re-measured with the three inset profiles injected, since `env()` is always 0 in a desktop browser:

| Inset profile | bar height | icon above screen bottom | first icon from left edge |
|---|---|---|---|
| none (older phone / browser tab) | 52px | 22px | 35px |
| portrait (top 47, bottom 34) | 86px | **56px** | 35px |
| landscape (sides 44) | 73px | 43px | **58px** |

The bottom row is the home-indicator fix: icons move from 22px to 56px above the screen bottom, clear of the indicator, and high enough that the corner curve no longer reaches them either. The landscape row shows `env()` correctly overriding the 1rem floor. No horizontal overflow in any profile.

Also checked: slot widths 48px at 320px and 57px at 390px (still above the 44px minimum), no label truncated at any width, `body` padding and `--bottom-nav-h` both inert at ≥768px with the desktop sidebar unchanged, `tsc --noEmit` and `npm run build` clean, and the generated CSS carries all four rules.

Incidentally confirmed with real data (this environment had API credentials this time), which #9 could not reach: every field on the Repositories tab — including the inline repo-text editor that started all of this — computes to 16px, zero offenders.

## Not verified

Real-device behaviour. The inset values above are simulated by injecting the CSS variables; the wiring is proven, the exact numbers iOS reports are not. Worth a look on the phone after merge, particularly in landscape.
