### PR TITLE
fix(ui): keep phones in landscape on the mobile layout

### DIFF
--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,24 +1,32 @@
 import { useState, useEffect } from 'react';
 
-const MOBILE_BREAKPOINT = 768;
+/**
+ * Must stay identical to the `md` screen in tailwind.config.js, or JS-driven
+ * behaviour (swipe navigation, chart sizing) disagrees with the CSS layout.
+ * Height is part of the test on purpose: a phone in landscape is 844x390 and
+ * would otherwise count as a desktop. See the comment on `screens.md` there.
+ */
+const DESKTOP_QUERY = '(min-width: 768px) and (min-height: 500px)';
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = useState<boolean>(() => {
     if (typeof window === 'undefined') return false;
-    return window.innerWidth < MOBILE_BREAKPOINT;
+    return !window.matchMedia(DESKTOP_QUERY).matches;
   });
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
-    const handleResize = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    };
+    // matchMedia rather than a resize listener: it fires on orientation change
+    // and on height-only changes (iOS toolbar collapse), which `resize` alone
+    // does not reliably report.
+    const mql = window.matchMedia(DESKTOP_QUERY);
+    const handleChange = () => setIsMobile(!mql.matches);
 
-    window.addEventListener('resize', handleResize);
-    handleResize();
+    mql.addEventListener('change', handleChange);
+    handleChange();
 
-    return () => window.removeEventListener('resize', handleResize);
+    return () => mql.removeEventListener('change', handleChange);
   }, []);
 
   return isMobile;

--- a/src/index.css
+++ b/src/index.css
@@ -160,12 +160,13 @@
     --bottom-nav-h: 0px;
   }
 
-  /* `not all and (min-width: …)` rather than `max-width: 767px`, so this is the
-     exact complement of Tailwind's `md:` and of the bar's own `md:hidden`. At a
+  /* `not all and (…)` rather than `max-width: …`, so this is the exact
+     complement of Tailwind's `md:` and of the bar's own `md:hidden`. At a
      fractional viewport width (browser zoom) `max-width: 767px` and
-     `min-width: 768px` are both false, which would leave the bar displayed at
-     zero height. */
-  @media not all and (min-width: 768px) {
+     `min-width: 768px` would both be false, leaving the bar displayed at zero
+     height. The height term must match `screens.md` in tailwind.config.js -
+     without it a landscape phone gets the desktop layout. */
+  @media not all and (min-width: 768px) and (min-height: 500px) {
     :root {
       --bottom-nav-h: calc(3.25rem + env(safe-area-inset-bottom, 0px));
     }
@@ -182,10 +183,10 @@
      `.text-sm` utility. Do not "simplify" them away.
      Verify changes here with getComputedStyle on a real field under 768px -
      never by reading the source.
-     `not all and (min-width: …)` keeps this the exact complement of the
-     `md:text-sm` half of the field components, with no gap at fractional
-     viewport widths. */
-  @media not all and (min-width: 768px) {
+     `not all and (…)` keeps this the exact complement of the `md:text-sm` half
+     of the field components, with no gap at fractional viewport widths, and the
+     height term keeps a landscape phone - still iOS, still zooming - on 16px. */
+  @media not all and (min-width: 768px) and (min-height: 500px) {
     input:not([type="range"]):not([type="checkbox"]):not([type="radio"]):not([data-small-ok]),
     textarea:not([data-small-ok]),
     select:not([data-small-ok]) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,18 @@ module.exports = {
       },
     },
     extend: {
+      // `md` is the switch between the mobile and the desktop layout: sidebar vs
+      // bottom nav, table vs cards, and every multi-column grid. Width alone is
+      // the wrong test - a phone in landscape is 844x390, so it cleared the old
+      // 768px and got the full desktop layout in a 390px-tall window: crushed
+      // grids, wrapped-to-death text, unusable filters.
+      // Requiring height too keeps landscape phones on the mobile layout, where
+      // they belong. 500px separates them (375-430px tall) from tablets in
+      // landscape (744px+). Keep `useIsMobile` and the complement queries in
+      // index.css in sync with this string.
+      screens: {
+        md: { raw: "(min-width: 768px) and (min-height: 500px)" },
+      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
Landscape on a phone was rendering the **full desktop layout in a 390px-tall window** — crushed grids, headings wrapping one word per line, unusable filters.

## Root cause

`md` is the switch between the mobile and the desktop layout — sidebar vs bottom nav, table vs cards, and every multi-column grid — and it tested **width only**. A phone in landscape is 844×390. 844 ≥ 768, so it counted as a desktop.

Width alone cannot distinguish a landscape phone from a small desktop window, so `md` now requires height too:

```js
md: { raw: "(min-width: 768px) and (min-height: 500px)" }
```

500px cleanly separates phones in landscape (375–430px tall) from tablets in landscape (744px+). All 41 existing `md:` usages switch with it — no per-component sweep, and nothing to keep in sync later.

Kept consistent with it:
- **`useIsMobile`** uses the identical query, or the JS-driven bits (swipe navigation, chart sizing) would disagree with the CSS. It also moves from a `resize` listener to `matchMedia`, which actually fires on orientation change and on height-only changes (iOS toolbar collapse) — `resize` does not report those reliably.
- **The two complement queries in `index.css`** follow, so `--bottom-nav-h` and the 16px field floor still cover exactly what `md:` does not. A landscape phone is still iOS and still zooms on a sub-16px field.

## Whose bug this is

Mostly pre-existing, and I want to be precise rather than generous to myself. The cards-vs-table `md:hidden` is from `aa95bf1` (2025-09-26) and the 768px threshold from `3701946` (2026-02-04) — both long before the bottom nav, and neither of my PRs touched those files. What #10 *did* add was 44px of body padding per side in landscape (`viewport-fit=cover`), which narrowed the already-crushed desktop columns further. On the mobile layout that padding is comfortably absorbed.

## Verification

Measured across form factors with the iframe harness, safe-area insets injected where a device would have them:

| Form factor | viewport | layout | bottom bar | h-overflow |
|---|---|---|---|---|
| iPhone 14 portrait | 390×780 | mobile | 86px (11%) | none |
| **iPhone 14 landscape** | 844×390 | **mobile** (was desktop) | 73px (19%) | none |
| iPad mini portrait | 744×1024 | mobile | 52px (5%) | none |
| iPad landscape | 1024×744 | desktop | — | none |
| desktop | 1296×896 | desktop | — | none |

In landscape specifically, after the fix: repository **cards** render and the table does not, the filter panel opens with **zero fields overflowing the viewport**, and no real text field computes under 16px (the four 14px hits are Radix `SelectTrigger` elements — `<button role="combobox">`, not text-entry, so iOS never zooms for them).

`tsc --noEmit` and `npm run build` clean. Generated CSS carries exactly two height-aware queries — the `md` one and its complement — with no bare `(min-width: 768px)` left anywhere.

## Worth deciding separately

In landscape the bottom bar is **73px of a 390px screen — 19% of the height**. It could drop the labels and slim to icons-only under `(max-height: 500px)`, but that trades a documented discoverability property, and I would not want to ship it unverified into an area that has already bitten twice. Say the word and I will do it as its own change.
