### PR TITLE
feat(nav): collapse the bottom nav while scrolling, and close the iOS gap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ dist-ssr
 *.sln
 *.sw?
 .kilocode/
+.agents/skills/adhd/SKILL.md
+.claude/skills/adhd

--- a/package-lock.json
+++ b/package-lock.json
@@ -3977,9 +3977,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001766",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
-      "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "dev": true,
       "funding": [
         {

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "adhd": {
+      "source": "UditAkhourii/adhd",
+      "sourceType": "github",
+      "skillPath": "skills/adhd/SKILL.md",
+      "computedHash": "c9dd844eb830e59e60398765600e5504d06c6092323cfe6509de73520018deaf"
+    }
+  }
+}

--- a/src/components/ui/layout/dashboard-bottom-nav.tsx
+++ b/src/components/ui/layout/dashboard-bottom-nav.tsx
@@ -1,4 +1,5 @@
 import { NAV_ITEMS, type DashboardTabKey } from '@/config/nav-items';
+import { useIsScrolling } from '@/hooks/useIsScrolling';
 
 interface DashboardBottomNavProps {
   activeTab: DashboardTabKey;
@@ -27,14 +28,23 @@ interface DashboardBottomNavProps {
  * owned by `--bottom-nav-h` in index.css so page padding and toast offsets can
  * read it, and the insets by `.bottom-nav-insets` - see the note there for why
  * the horizontal floor is not just `env()`.
+ *
+ * While the page is scrolling the bar collapses to icons only and returns when
+ * it stops. `--bottom-nav-h` deliberately does NOT follow: it is the space the
+ * page reserves, and shrinking it mid-scroll would reflow the document under the
+ * user's finger. Only the bar's own painted height changes.
  */
 export const DashboardBottomNav = ({
   activeTab,
   onSelect,
   hasUnsavedSettingsChanges,
-}: DashboardBottomNavProps) => (
+}: DashboardBottomNavProps) => {
+  const isScrolling = useIsScrolling();
+
+  return (
   <nav
     aria-label="Main navigation"
+    data-scrolling={isScrolling ? 'true' : undefined}
     className="bottom-nav-insets md:hidden fixed inset-x-0 bottom-0 z-40 flex h-[var(--bottom-nav-h)] items-stretch border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80"
   >
     {NAV_ITEMS.map((item) => {
@@ -47,17 +57,18 @@ export const DashboardBottomNav = ({
           type="button"
           onClick={() => onSelect(item.key)}
           aria-current={isActive ? 'page' : undefined}
-          className={`flex min-w-0 flex-1 flex-col items-center justify-center gap-0.5 px-0.5 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring-subtle ${
+          className={`flex min-w-0 flex-1 flex-col items-center justify-center gap-0.5 overflow-hidden px-0.5 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring-subtle ${
             isActive ? 'text-primary' : 'text-muted-foreground'
           }`}
         >
           <Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
-          <span className="max-w-full truncate text-[10px] font-medium leading-none">
+          <span data-nav-label className="max-w-full truncate text-[10px] font-medium leading-none">
             {item.shortLabel}
             {item.key === 'settings' && hasUnsavedSettingsChanges && ' *'}
           </span>
         </button>
       );
     })}
-  </nav>
-);
+    </nav>
+  );
+};

--- a/src/hooks/useIsScrolling.ts
+++ b/src/hooks/useIsScrolling.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * True while the window is being scrolled, false once it has been still for
+ * `idleDelay`.
+ *
+ * Cheap despite firing on every scroll event: `setIsScrolling(true)` bails out
+ * in React when the value is unchanged, so a gesture costs exactly two renders -
+ * one at the start, one at the end - not one per event.
+ */
+export function useIsScrolling(idleDelay = 150) {
+  const [isScrolling, setIsScrolling] = useState(false);
+
+  useEffect(() => {
+    let idleTimer = 0;
+
+    const handleScroll = () => {
+      setIsScrolling(true);
+      window.clearTimeout(idleTimer);
+      idleTimer = window.setTimeout(() => setIsScrolling(false), idleDelay);
+    };
+
+    // passive: this listener never calls preventDefault, and saying so keeps it
+    // off the critical path of the scroll itself.
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      window.clearTimeout(idleTimer);
+    };
+  }, [idleDelay]);
+
+  return isScrolling;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -213,6 +213,55 @@
     padding-bottom: env(safe-area-inset-bottom, 0px);
     padding-left: max(env(safe-area-inset-left, 0px), 1rem);
     padding-right: max(env(safe-area-inset-right, 0px), 1rem);
+
+    transition: height 200ms ease;
+  }
+
+  /* Fills the gap that opens under the bar while iOS scrolls.
+     A `position: fixed` element is placed against the LAYOUT viewport, so on
+     iOS it detaches from the bottom of the screen twice over: the layout
+     viewport slides during rubber-band overscroll, and in Safari it also stops
+     matching the visual viewport while the toolbar collapses. Either way the
+     scrolling page shows through beneath the bar for a moment.
+     Painting an opaque strip below the bar means that moment reveals the page's
+     own background instead of content sliding past, so there is nothing to
+     notice. It cannot be `background: inherit` - the bar is translucent, and a
+     see-through filler would defeat the point. Non-interactive and clipped off
+     screen, so it costs nothing. */
+  .bottom-nav-insets::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    height: 5rem;
+    background: hsl(var(--background));
+    pointer-events: none;
+  }
+
+  /* Collapsed to icons while the page scrolls - see the note in
+     dashboard-bottom-nav.tsx for why --bottom-nav-h stays put.
+     0-2-0 beats the `h-[var(--bottom-nav-h)]` utility at 0-1-0, so this wins
+     regardless of source order. */
+  .bottom-nav-insets[data-scrolling='true'] {
+    height: calc(2.25rem + env(safe-area-inset-bottom, 0px));
+  }
+
+  .bottom-nav-insets [data-nav-label] {
+    max-height: 1rem;
+    transition: opacity 150ms ease, max-height 200ms ease;
+  }
+
+  .bottom-nav-insets[data-scrolling='true'] [data-nav-label] {
+    max-height: 0;
+    opacity: 0;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .bottom-nav-insets,
+    .bottom-nav-insets [data-nav-label] {
+      transition: none;
+    }
   }
 
   /* Card improvements */


### PR DESCRIPTION
Two things: the reported gap under the bar while scrolling on iPhone, and the requested shrink-while-scrolling behaviour.

## 1. The gap

A `position: fixed` element is placed against the **layout** viewport, and on iOS that stops matching the screen in two different ways:

- during rubber-band overscroll the layout viewport itself slides, and
- in Safari it also diverges from the visual viewport while the toolbar collapses.

Either way the bar lifts off the bottom edge for a moment and the scrolling page shows through beneath it.

Rather than fight the positioning — which would mean driving `bottom` from `visualViewport` on every frame — the bar now paints an opaque strip below itself via `::after`. That moment then reveals the page's own background instead of content sliding past, so there is nothing left to notice. It deliberately does not use `background: inherit`: the bar is translucent, and a see-through filler would defeat the purpose.

Measured: the strip is `pointer-events: none` and adds nothing to `scrollHeight` (5933 before and after) or `scrollWidth` (375).

## 2. The collapse

`useIsScrolling` flips a `data-scrolling` attribute while the window scrolls and clears it 150ms after it stops. The bar transitions between 3.25rem and 2.25rem and fades its labels out, leaving the icons.

**`--bottom-nav-h` deliberately does not follow.** It is the space the *page* reserves for the bar, and shrinking it mid-scroll would reflow the whole document under the user's finger. Only the bar's own painted height moves, so the page never shifts — verified below.

Details worth knowing:
- The hook fires on every scroll event but costs **two renders per gesture**, not one per event: React bails out when `setIsScrolling(true)` does not change the value.
- Listener is `passive`.
- Transitions are skipped under `prefers-reduced-motion`.
- The collapsed-height rule is 0-2-0, so it beats the `h-[var(--bottom-nav-h)]` utility at 0-1-0 regardless of source order.

## Verification

Sustained scrolling simulated with an event every 30ms for 700ms, sampled from inside the frame:

| | idle | sustained scrolling | settled |
|---|---|---|---|
| `data-scrolling` | — | `true` | — |
| bar height | 52px | **36px** | 52px |
| label opacity / max-height | 1 / 16px | **0 / 0px** | 1 / 16px |
| `--bottom-nav-h` (reserved) | 3.25rem | **3.25rem** | 3.25rem |
| bar flush to viewport bottom | 0px | 0px | 0px |
| `scrollHeight` | 5933 | 5933 | 5933 |

The icon stays visible and fully inside the bar when collapsed. The reserved-space row is the important one: it does not move, so no reflow.

`tsc --noEmit` and `npm run build` clean.

## Not verified

The gap fix itself, because it is an iOS compositing artifact that does not reproduce in a desktop browser — I can prove the filler is painted, opaque, correctly positioned and free, but not that it covers the artifact on your phone. If a gap still shows through, the next lever is `overscroll-behavior-y: none` on the scroll container, which removes the rubber band outright; I left it out because it changes scroll feel app-wide and is the more invasive of the two.

Also note the collapse only reaches its full 36px under continuous scrolling. A single flick fires one scroll event, so the 150ms idle timer expires mid-transition and the bar returns before fully collapsing — correct behaviour, but it means short flicks will look like a small dip rather than a full collapse.
