### PR TITLE
feat(repositories): choose between publish next and publish now

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -36,6 +36,13 @@ export interface RetryMessageResult {
   succeeded?: string[] | null;
   failed?: string[] | null;
   outcomes?: RetryMessageOutcome[] | null;
+  /** Whether the repository was marked as published and left the queue. */
+  posted?: boolean;
+  /**
+   * Present only when that marking failed: the post went out but the repository
+   * stayed in the queue, so the scheduled run will publish it again.
+   */
+  posted_error?: string;
 }
 
 export interface CronJobHistoryResponse {
@@ -198,6 +205,47 @@ export const retryMessagePost = async (
     // Content Maestro answers errors as plain text.
     const detail = (await response.text()).trim();
     throw new Error(detail || `Failed to retry the publication: ${response.status}`);
+  }
+
+  return response.json();
+};
+
+/**
+ * Publishes a repository immediately to every enabled integration, instead of
+ * waiting for its turn in the publication queue. Content Maestro resolves the
+ * integrations itself: the dashboard's cached list must not decide what is sent.
+ *
+ * The request is synchronous and can take minutes - the Threads connector alone
+ * is configured with a 90 s timeout - so callers pass a signal and must treat an
+ * abort as "may still be running", not as "did not publish".
+ */
+export const publishMessageNow = async (
+  url: string,
+  options?: { signal?: AbortSignal }
+): Promise<RetryMessageResult> => {
+  const settings = getApiSettings();
+
+  if (!isApiConfigured()) {
+    throw new Error("API not configured. Check the Content Maestro settings.");
+  }
+
+  const response = await fetch(`${settings.contentMaestro.apiBaseUrl}/api/message/publish`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${settings.contentMaestro.apiBearerToken}`,
+    },
+    body: JSON.stringify({ url }),
+    signal: options?.signal,
+  });
+
+  if (!response.ok) {
+    if (response.status === 429) {
+      throw new Error("Rate limit exceeded. Please try again later.");
+    }
+    // Content Maestro answers errors as plain text.
+    const detail = (await response.text()).trim();
+    throw new Error(detail || `Failed to publish the repository: ${response.status}`);
   }
 
   return response.json();

--- a/src/components/ui/base/dialog.tsx
+++ b/src/components/ui/base/dialog.tsx
@@ -27,10 +27,19 @@ const DialogOverlay = React.forwardRef<
 ))
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
+interface DialogContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  /**
+   * Blocks the built-in close button while an operation must not be interrupted -
+   * closing mid-run would throw away the only place its result is shown.
+   */
+  closeDisabled?: boolean;
+}
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  DialogContentProps
+>(({ className, children, closeDisabled, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -42,7 +51,10 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring-subtle focus:ring-offset-1 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close
+        disabled={closeDisabled}
+        className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring-subtle focus:ring-offset-1 disabled:pointer-events-none disabled:opacity-30 data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
+      >
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/src/components/ui/business/publish-repository-dialog.tsx
+++ b/src/components/ui/business/publish-repository-dialog.tsx
@@ -29,7 +29,14 @@ interface PublishRepositoryDialogProps {
   isApiReady: boolean;
   /** The enabled integrations a publish-now will reach. */
   integrations: PublishIntegration[];
+  /** True while the integration list is still being fetched. */
+  integrationsLoading?: boolean;
   onClose: () => void;
+  /**
+   * Reports whether a request is in flight, so the caller can stop the row
+   * buttons from retargeting this dialog mid-publication.
+   */
+  onBusyChange?: (busy: boolean) => void;
   /** Promotes to the head of the queue - the caller's existing handler and toast. */
   onPromote: (repo: Repository) => Promise<void>;
   /** Called once the publication may have changed anything, so the caller refreshes. */
@@ -56,7 +63,9 @@ export function PublishRepositoryDialog({
   isNext,
   isApiReady,
   integrations,
+  integrationsLoading = false,
   onClose,
+  onBusyChange,
   onPromote,
   onPublished,
 }: PublishRepositoryDialogProps) {
@@ -64,9 +73,17 @@ export function PublishRepositoryDialog({
   const [result, setResult] = useState<RetryMessageResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  // The repository the state on screen belongs to. One dialog instance serves
+  // every row, so a request that outlives its own target must not write its
+  // outcome into the dialog somebody has since pointed at another repository.
+  const targetIdRef = useRef<number | null>(repository?.id ?? null);
 
-  // Reopening on another row must never show the previous run's rows.
+  // Reopening on another row must never show the previous run's rows, and the
+  // request that filled them has to be dropped rather than left to land later.
   useEffect(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    targetIdRef.current = repository?.id ?? null;
     setPhase('idle');
     setResult(null);
     setError(null);
@@ -75,6 +92,10 @@ export function PublishRepositoryDialog({
   useEffect(() => () => abortRef.current?.abort(), []);
 
   const busy = phase === 'promoting' || phase === 'publishing';
+
+  useEffect(() => {
+    onBusyChange?.(busy);
+  }, [busy, onBusyChange]);
   const rows = buildPublishRows(integrations, phase === 'idle' || phase === 'promoting' ? null : result);
   const summary = result ? summarizePublishResult(result) : null;
 
@@ -96,8 +117,13 @@ export function PublishRepositoryDialog({
   const handlePublishNow = async () => {
     if (!repository || phase !== 'idle') return;
 
+    const targetId = repository.id;
     const controller = new AbortController();
-    const timeout = window.setTimeout(() => controller.abort(), PUBLISH_TIMEOUT_MS);
+    const timedOut = { value: false };
+    const timeout = window.setTimeout(() => {
+      timedOut.value = true;
+      controller.abort();
+    }, PUBLISH_TIMEOUT_MS);
     abortRef.current = controller;
     setPhase('publishing');
     setError(null);
@@ -106,13 +132,17 @@ export function PublishRepositoryDialog({
     try {
       const publishResult = await publishMessageNow(repository.url, { signal: controller.signal });
       answered = true;
+      if (targetIdRef.current !== targetId) return;
       setResult(publishResult);
       if (publishedSomething(publishResult)) {
         await onPublished();
       }
     } catch (err) {
+      // Retargeting the dialog aborts this request on purpose; its outcome
+      // belongs to a repository nobody is looking at any more.
+      if (targetIdRef.current !== targetId) return;
       setError(
-        controller.signal.aborted
+        timedOut.value
           ? 'Content Maestro did not answer in time. The publication may still be running — check Cron History before trying again.'
           : maestroErrorMessage(err)
       );
@@ -121,12 +151,16 @@ export function PublishRepositoryDialog({
       await onPublished();
     } finally {
       window.clearTimeout(timeout);
-      abortRef.current = null;
-      // A request that never produced a result leaves the choices in place, with
-      // the error above them: refusals (a cron run holding the lock, an item
-      // already published) are the kind of thing that is worth another try, and
-      // the backend refuses a duplicate on its own.
-      setPhase(answered ? 'done' : 'idle');
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+      }
+      if (targetIdRef.current === targetId) {
+        // A request that never produced a result leaves the choices in place, with
+        // the error above them: refusals (a cron run holding the lock, an item
+        // already published) are the kind of thing that is worth another try, and
+        // the backend refuses a duplicate on its own.
+        setPhase(answered ? 'done' : 'idle');
+      }
     }
   };
 
@@ -180,14 +214,21 @@ export function PublishRepositoryDialog({
     <Dialog
       open={repository !== null}
       onOpenChange={open => {
-        if (!open && !busy) onClose();
+        if (!open && phase !== 'publishing') onClose();
       }}
     >
+      {/*
+        Only a publication in flight blocks dismissal: its per-integration result
+        exists nowhere else, so closing mid-run would throw it away. Promoting is
+        not blocked - it has no in-dialog result to lose, and the promote request
+        carries no timeout, so blocking it would make a stalled backend leave a
+        dialog that cannot be closed at all.
+      */}
       <DialogContent
         className="max-w-lg"
-        closeDisabled={busy}
-        onEscapeKeyDown={event => busy && event.preventDefault()}
-        onPointerDownOutside={event => busy && event.preventDefault()}
+        closeDisabled={phase === 'publishing'}
+        onEscapeKeyDown={event => phase === 'publishing' && event.preventDefault()}
+        onPointerDownOutside={event => phase === 'publishing' && event.preventDefault()}
       >
         <DialogHeader>
           <DialogTitle>Publish repository</DialogTitle>
@@ -241,12 +282,19 @@ export function PublishRepositoryDialog({
               </h4>
               <ul className="space-y-1 text-sm">{rows.map(renderRow)}</ul>
             </div>
-          ) : isApiReady ? (
+          ) : !isApiReady ? null : integrationsLoading ? (
+            // An empty list while the configs are still loading is not the same as
+            // no integration being enabled, and saying so would be wrong.
+            <p className="text-sm text-muted-foreground flex items-center gap-2">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Loading integrations...
+            </p>
+          ) : (
             <p className="bg-warning/10 text-warning p-3 rounded-md text-sm">
               No integration is enabled, so there is nothing to publish to. Enable one on the
               Integrations tab.
             </p>
-          ) : null}
+          )}
         </div>
 
         <DialogFooter>
@@ -256,7 +304,7 @@ export function PublishRepositoryDialog({
             </Button>
           ) : (
             <>
-              <Button variant="outline" onClick={onClose} disabled={busy}>
+              <Button variant="outline" onClick={onClose} disabled={phase === 'publishing'}>
                 Cancel
               </Button>
               <Button
@@ -274,7 +322,7 @@ export function PublishRepositoryDialog({
               </Button>
               <Button
                 onClick={handlePublishNow}
-                disabled={busy || !isApiReady || integrations.length === 0}
+                disabled={busy || !isApiReady || integrationsLoading || integrations.length === 0}
               >
                 {phase === 'publishing' ? (
                   <>

--- a/src/components/ui/business/publish-repository-dialog.tsx
+++ b/src/components/ui/business/publish-repository-dialog.tsx
@@ -183,7 +183,7 @@ export function PublishRepositoryDialog({
           <span className="font-medium text-foreground capitalize">{row.name}</span>
           {flag && <span aria-hidden="true">{flag}</span>}
           <span className="ml-auto flex items-center gap-1 text-xs">
-            {row.state === 'pending' && (
+            {row.state === 'pending' && phase === 'publishing' && (
               <>
                 <Loader2 className="h-3 w-3 animate-spin" />
                 Sending...

--- a/src/components/ui/business/publish-repository-dialog.tsx
+++ b/src/components/ui/business/publish-repository-dialog.tsx
@@ -1,0 +1,297 @@
+import { useEffect, useRef, useState } from 'react';
+import { AlertTriangle, Check, Clock, Loader2, Send, X } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../base/dialog';
+import { Button } from '../base/button';
+import { IntegrationIcon, getLanguageFlag } from './integration-icons';
+import { publishMessageNow, type RetryMessageResult } from '../../../api/index';
+import { maestroErrorMessage } from '../../../utils/api-error';
+import {
+  buildPublishRows,
+  publishedSomething,
+  summarizePublishResult,
+  type PublishIntegration,
+  type PublishRow,
+} from '../../../utils/message-publish';
+import type { Repository } from '../../../types';
+
+interface PublishRepositoryDialogProps {
+  /** The repository being published; null keeps the dialog closed. */
+  repository: Repository | null;
+  /** True when this repository already sits at the head of the publication queue. */
+  isNext: boolean;
+  isApiReady: boolean;
+  /** The enabled integrations a publish-now will reach. */
+  integrations: PublishIntegration[];
+  onClose: () => void;
+  /** Promotes to the head of the queue - the caller's existing handler and toast. */
+  onPromote: (repo: Repository) => Promise<void>;
+  /** Called once the publication may have changed anything, so the caller refreshes. */
+  onPublished: () => void | Promise<void>;
+}
+
+type Phase = 'idle' | 'promoting' | 'publishing' | 'done';
+
+/**
+ * A safety net rather than a cancellation: aborting the request does not stop the
+ * run on the server, so the timeout has to sit well above the slowest legitimate
+ * publication (image generation plus the Threads connector's own 90 s timeout).
+ */
+const PUBLISH_TIMEOUT_MS = 240_000;
+
+const toneStyles = {
+  success: 'bg-success/20 text-success',
+  partial: 'bg-warning/10 text-warning',
+  error: 'bg-destructive/10 text-destructive',
+} as const;
+
+export function PublishRepositoryDialog({
+  repository,
+  isNext,
+  isApiReady,
+  integrations,
+  onClose,
+  onPromote,
+  onPublished,
+}: PublishRepositoryDialogProps) {
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [result, setResult] = useState<RetryMessageResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Reopening on another row must never show the previous run's rows.
+  useEffect(() => {
+    setPhase('idle');
+    setResult(null);
+    setError(null);
+  }, [repository?.id]);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const busy = phase === 'promoting' || phase === 'publishing';
+  const rows = buildPublishRows(integrations, phase === 'idle' || phase === 'promoting' ? null : result);
+  const summary = result ? summarizePublishResult(result) : null;
+
+  const handlePromote = async () => {
+    if (!repository || busy) return;
+
+    setPhase('promoting');
+    try {
+      await onPromote(repository);
+      onClose();
+    } catch {
+      // The caller already reported it with a toast; the dialog stays open so the
+      // action can be retried or the other one picked instead.
+    } finally {
+      setPhase('idle');
+    }
+  };
+
+  const handlePublishNow = async () => {
+    if (!repository || phase !== 'idle') return;
+
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), PUBLISH_TIMEOUT_MS);
+    abortRef.current = controller;
+    setPhase('publishing');
+    setError(null);
+    let answered = false;
+
+    try {
+      const publishResult = await publishMessageNow(repository.url, { signal: controller.signal });
+      answered = true;
+      setResult(publishResult);
+      if (publishedSomething(publishResult)) {
+        await onPublished();
+      }
+    } catch (err) {
+      setError(
+        controller.signal.aborted
+          ? 'Content Maestro did not answer in time. The publication may still be running — check Cron History before trying again.'
+          : maestroErrorMessage(err)
+      );
+      // The run may have published before the connection broke, so the list has
+      // to be refreshed either way.
+      await onPublished();
+    } finally {
+      window.clearTimeout(timeout);
+      abortRef.current = null;
+      // A request that never produced a result leaves the choices in place, with
+      // the error above them: refusals (a cron run holding the lock, an item
+      // already published) are the kind of thing that is worth another try, and
+      // the backend refuses a duplicate on its own.
+      setPhase(answered ? 'done' : 'idle');
+    }
+  };
+
+  const renderRow = (row: PublishRow) => {
+    const flag = getLanguageFlag(row.textLanguage);
+
+    return (
+      <li
+        key={row.name}
+        className={`p-2 rounded-md flex flex-col gap-1 ${
+          row.state === 'success'
+            ? 'bg-success/20 text-success'
+            : row.state === 'failure'
+              ? 'bg-destructive/10 border border-destructive/20'
+              : 'bg-muted/50 text-muted-foreground'
+        }`}
+      >
+        <div className="flex items-center gap-2">
+          <IntegrationIcon name={row.name} className="w-4 h-4 shrink-0" />
+          <span className="font-medium text-foreground capitalize">{row.name}</span>
+          {flag && <span aria-hidden="true">{flag}</span>}
+          <span className="ml-auto flex items-center gap-1 text-xs">
+            {row.state === 'pending' && (
+              <>
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Sending...
+              </>
+            )}
+            {row.state === 'success' && (
+              <>
+                <Check className="h-3 w-3" />
+                Sent
+              </>
+            )}
+            {row.state === 'failure' && (
+              <>
+                <X className="h-3 w-3 text-destructive" />
+                <span className="text-destructive">Failed</span>
+              </>
+            )}
+          </span>
+        </div>
+        {row.state === 'failure' && row.error && (
+          <span className="text-xs dark:text-red-400 text-red-600 break-words">{row.error}</span>
+        )}
+      </li>
+    );
+  };
+
+  return (
+    <Dialog
+      open={repository !== null}
+      onOpenChange={open => {
+        if (!open && !busy) onClose();
+      }}
+    >
+      <DialogContent
+        className="max-w-lg"
+        closeDisabled={busy}
+        onEscapeKeyDown={event => busy && event.preventDefault()}
+        onPointerDownOutside={event => busy && event.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>Publish repository</DialogTitle>
+          <DialogDescription className="break-all">
+            {repository?.url.replace('https://github.com/', '')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          {!isApiReady && (
+            <p className="bg-warning/10 text-warning p-3 rounded-md text-sm">
+              Content Maestro API is not configured — check Settings.
+            </p>
+          )}
+
+          {phase === 'idle' && isApiReady && (
+            <div className="space-y-1 text-sm text-muted-foreground">
+              <p>
+                <span className="text-foreground font-medium">Publish next</span> moves this
+                repository to the head of the queue; the scheduled run publishes it.
+              </p>
+              <p>
+                <span className="text-foreground font-medium">Publish now</span> sends it
+                immediately to every enabled integration.
+              </p>
+            </div>
+          )}
+
+          {summary && (
+            <p className={`p-3 rounded-md text-sm ${toneStyles[summary.tone]}`}>{summary.text}</p>
+          )}
+
+          {error && (
+            <p className="bg-destructive/10 text-destructive p-3 rounded-md text-sm flex items-start gap-2">
+              <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+              <span className="break-words">{error}</span>
+            </p>
+          )}
+
+          {result?.posted_error && (
+            <p className="bg-warning/10 text-warning p-3 rounded-md text-sm">
+              Published, but the repository could not be marked as posted — the scheduled run may
+              publish it again. ({result.posted_error})
+            </p>
+          )}
+
+          {rows.length > 0 ? (
+            <div>
+              <h4 className="text-sm font-medium mb-2">
+                {phase === 'done' ? 'Integrations:' : 'Will publish to:'}
+              </h4>
+              <ul className="space-y-1 text-sm">{rows.map(renderRow)}</ul>
+            </div>
+          ) : isApiReady ? (
+            <p className="bg-warning/10 text-warning p-3 rounded-md text-sm">
+              No integration is enabled, so there is nothing to publish to. Enable one on the
+              Integrations tab.
+            </p>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          {phase === 'done' ? (
+            <Button variant="outline" onClick={onClose}>
+              Close
+            </Button>
+          ) : (
+            <>
+              <Button variant="outline" onClick={onClose} disabled={busy}>
+                Cancel
+              </Button>
+              <Button
+                variant="outline"
+                onClick={handlePromote}
+                disabled={busy || isNext || !isApiReady}
+                title={isNext ? 'Already next in the queue' : undefined}
+              >
+                {phase === 'promoting' ? (
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                ) : (
+                  <Clock className="h-4 w-4 mr-2" />
+                )}
+                Publish next
+              </Button>
+              <Button
+                onClick={handlePublishNow}
+                disabled={busy || !isApiReady || integrations.length === 0}
+              >
+                {phase === 'publishing' ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Publishing...
+                  </>
+                ) : (
+                  <>
+                    <Send className="h-4 w-4 mr-2" />
+                    Publish now
+                  </>
+                )}
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/business/repository-list.tsx
+++ b/src/components/ui/business/repository-list.tsx
@@ -1,5 +1,6 @@
 // React imports
 // (no state needed since the Posts section is no longer collapsible)
+import type { ApiConfig } from '@/api/api-configs';
 import type { Repository, RepositorySortBy, RepositorySortOrder } from '@/types';
 import { Filter, ChevronDown } from 'lucide-react';
 import { filterRepositories, countActiveFilters } from '@/utils/repositoryListUtils';
@@ -17,6 +18,8 @@ interface RepositoryListProps {
   fetchRepositories: (posted?: boolean, append?: boolean, fetchAll?: boolean, itemsPerPage?: number, sortBy?: RepositorySortBy, sortOrder?: RepositorySortOrder, page?: number, forceFetch?: boolean) => Promise<void>;
   fetchPreviews: (forceFetch?: boolean) => Promise<void>;
   nextPostId?: number;
+  /** Integration configs, so the publish dialog can list the enabled ones. */
+  integrations?: ApiConfig[];
   totalItems: number;
   totalPages: number;
   currentPage: number;
@@ -31,6 +34,7 @@ export function RepositoryList({
   fetchRepositories, 
   fetchPreviews,
   nextPostId,
+  integrations,
   totalItems, 
   totalPages, 
   currentPage: initialPage, 
@@ -139,6 +143,7 @@ export function RepositoryList({
               itemsPerPage={itemsPerPage}
               searchTerm={searchTerm}
               nextPostId={nextPostId}
+              integrations={integrations}
               onRepositoryUpdate={handleRepositoryUpdate}
               onRepositoryArchived={onRepositoryArchived}
             />
@@ -153,6 +158,7 @@ export function RepositoryList({
               itemsPerPage={itemsPerPage}
               searchTerm={searchTerm}
               nextPostId={nextPostId}
+              integrations={integrations}
               onRepositoryUpdate={handleRepositoryUpdate}
               onRepositoryArchived={onRepositoryArchived}
             />

--- a/src/components/ui/business/repository-list.tsx
+++ b/src/components/ui/business/repository-list.tsx
@@ -20,6 +20,8 @@ interface RepositoryListProps {
   nextPostId?: number;
   /** Integration configs, so the publish dialog can list the enabled ones. */
   integrations?: ApiConfig[];
+  /** True while those configs are still being fetched. */
+  integrationsLoading?: boolean;
   totalItems: number;
   totalPages: number;
   currentPage: number;
@@ -35,6 +37,7 @@ export function RepositoryList({
   fetchPreviews,
   nextPostId,
   integrations,
+  integrationsLoading,
   totalItems, 
   totalPages, 
   currentPage: initialPage, 
@@ -144,6 +147,7 @@ export function RepositoryList({
               searchTerm={searchTerm}
               nextPostId={nextPostId}
               integrations={integrations}
+              integrationsLoading={integrationsLoading}
               onRepositoryUpdate={handleRepositoryUpdate}
               onRepositoryArchived={onRepositoryArchived}
             />
@@ -159,6 +163,7 @@ export function RepositoryList({
               searchTerm={searchTerm}
               nextPostId={nextPostId}
               integrations={integrations}
+              integrationsLoading={integrationsLoading}
               onRepositoryUpdate={handleRepositoryUpdate}
               onRepositoryArchived={onRepositoryArchived}
             />

--- a/src/components/ui/business/repository-mobile-view.tsx
+++ b/src/components/ui/business/repository-mobile-view.tsx
@@ -8,6 +8,8 @@ import { Pencil, Check, X, Trash2, AlertCircle, Archive, Send } from 'lucide-rea
 import { describeArchiveFailure, isStaleArchiveFailure, summarizeArchiveResult } from '@/utils/archiveUtils';
 import { toast } from '@/components/ui/common/toast-config';
 import { ConfirmDialog } from '@/components/ui/common/confirm-dialog';
+import { PublishRepositoryDialog } from './publish-repository-dialog';
+import { enabledIntegrations } from '@/utils/message-publish';
 import { RepositoryLink } from '@/components/ui/common/repository-link';
 import { Button } from '../base/button';
 import { Label } from '../base/label';
@@ -24,6 +26,7 @@ export function RepositoryMobileView({
   itemsPerPage,
   searchTerm,
   nextPostId,
+  integrations,
   onRepositoryUpdate,
   onRepositoryArchived
 }: RepositoryMobileViewProps) {
@@ -34,7 +37,7 @@ export function RepositoryMobileView({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<Repository | null>(null);
   const [showArchiveConfirm, setShowArchiveConfirm] = useState<Repository | null>(null);
   const [archivingId, setArchivingId] = useState<number | null>(null);
-  const [showPromoteConfirm, setShowPromoteConfirm] = useState<Repository | null>(null);
+  const [publishTarget, setPublishTarget] = useState<Repository | null>(null);
   const [promotingId, setPromotingId] = useState<number | null>(null);
   const textInputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -211,7 +214,12 @@ export function RepositoryMobileView({
 
     try {
       setPromotingId(repo.id);
-      await promoteRepositoryToNext({ id: repo.id });
+      const result = await promoteRepositoryToNext({ id: repo.id });
+      // An unconfigured API answers with an error payload instead of throwing, and
+      // reporting success for a request that never left the browser is a lie.
+      if (result.status === 'error') {
+        throw new Error(result.message);
+      }
 
       toast.success(`Repository will be published next`, {
         ...toastOptions,
@@ -227,6 +235,8 @@ export function RepositoryMobileView({
         ...toastOptions,
         id: `promote-error-${repo.id}`
       });
+      // Rethrown so the publish dialog keeps itself open on a failed promotion.
+      throw error;
     } finally {
       setPromotingId(null);
     }
@@ -355,11 +365,11 @@ export function RepositoryMobileView({
                         <Button
                           variant="ghost"
                           size="icon"
-                          onClick={() => setShowPromoteConfirm(repo)}
-                          disabled={repo.id === nextPostId || promotingId !== null}
-                          aria-label={repo.id === nextPostId ? 'Already next' : 'Publish next'}
+                          onClick={() => setPublishTarget(repo)}
+                          disabled={!isApiReady || promotingId !== null}
+                          aria-label="Publish"
                           className="h-8 w-8 text-muted-foreground hover:text-foreground disabled:opacity-50"
-                          title={repo.id === nextPostId ? 'Already next' : 'Publish next'}
+                          title="Publish"
                         >
                           <Send className="h-4 w-4" />
                         </Button>
@@ -459,20 +469,18 @@ export function RepositoryMobileView({
         onCancel={() => setShowArchiveConfirm(null)}
       />
 
-      <ConfirmDialog
-        isOpen={showPromoteConfirm !== null}
-        title="Publish Next"
-        message="Publish this repository in the next posting cycle?"
-        confirmText="Publish"
-        cancelText="Cancel"
-        variant="info"
-        onConfirm={() => {
-          if (showPromoteConfirm) {
-            handlePromoteRepository(showPromoteConfirm);
+      <PublishRepositoryDialog
+        repository={publishTarget}
+        isNext={publishTarget !== null && publishTarget.id === nextPostId}
+        isApiReady={isApiReady}
+        integrations={enabledIntegrations(integrations ?? [])}
+        onClose={() => setPublishTarget(null)}
+        onPromote={handlePromoteRepository}
+        onPublished={async () => {
+          if (onRepositoryUpdate) {
+            await onRepositoryUpdate();
           }
-          setShowPromoteConfirm(null);
         }}
-        onCancel={() => setShowPromoteConfirm(null)}
       />
     </>
   );

--- a/src/components/ui/business/repository-mobile-view.tsx
+++ b/src/components/ui/business/repository-mobile-view.tsx
@@ -27,6 +27,7 @@ export function RepositoryMobileView({
   searchTerm,
   nextPostId,
   integrations,
+  integrationsLoading,
   onRepositoryUpdate,
   onRepositoryArchived
 }: RepositoryMobileViewProps) {
@@ -38,6 +39,9 @@ export function RepositoryMobileView({
   const [showArchiveConfirm, setShowArchiveConfirm] = useState<Repository | null>(null);
   const [archivingId, setArchivingId] = useState<number | null>(null);
   const [publishTarget, setPublishTarget] = useState<Repository | null>(null);
+  // One dialog instance serves every row, so retargeting it while it is working
+  // would leave a request writing its outcome into somebody else's repository.
+  const [publishBusy, setPublishBusy] = useState(false);
   const [promotingId, setPromotingId] = useState<number | null>(null);
   const textInputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -210,10 +214,19 @@ export function RepositoryMobileView({
   };
 
   const handlePromoteRepository = async (repo: Repository) => {
-    if (repo.posted || repo.id === nextPostId || promotingId !== null) return;
+    if (promotingId !== null) return;
 
     try {
       setPromotingId(repo.id);
+      // nextPostId is a render-time value, so another tab - or the cron - can have
+      // moved the queue on since this row was drawn. Saying so beats closing the
+      // dialog as if a promotion that never happened had succeeded.
+      if (repo.posted) {
+        throw new Error('Repository is already published');
+      }
+      if (repo.id === nextPostId) {
+        throw new Error('Repository is already next in the queue');
+      }
       const result = await promoteRepositoryToNext({ id: repo.id });
       // An unconfigured API answers with an error payload instead of throwing, and
       // reporting success for a request that never left the browser is a lie.
@@ -366,10 +379,10 @@ export function RepositoryMobileView({
                           variant="ghost"
                           size="icon"
                           onClick={() => setPublishTarget(repo)}
-                          disabled={!isApiReady || promotingId !== null}
-                          aria-label="Publish"
+                          disabled={!isApiReady || promotingId !== null || publishBusy}
+                          aria-label={repo.id === nextPostId ? 'Publish (already next in the queue)' : 'Publish'}
                           className="h-8 w-8 text-muted-foreground hover:text-foreground disabled:opacity-50"
-                          title="Publish"
+                          title={repo.id === nextPostId ? 'Publish (already next in the queue)' : 'Publish'}
                         >
                           <Send className="h-4 w-4" />
                         </Button>
@@ -474,7 +487,9 @@ export function RepositoryMobileView({
         isNext={publishTarget !== null && publishTarget.id === nextPostId}
         isApiReady={isApiReady}
         integrations={enabledIntegrations(integrations ?? [])}
+        integrationsLoading={integrationsLoading}
         onClose={() => setPublishTarget(null)}
+        onBusyChange={setPublishBusy}
         onPromote={handlePromoteRepository}
         onPublished={async () => {
           if (onRepositoryUpdate) {

--- a/src/components/ui/business/repository-table.tsx
+++ b/src/components/ui/business/repository-table.tsx
@@ -7,6 +7,8 @@ import { Pencil, Check, X, Trash2, AlertCircle, Archive, ChevronDown, ChevronUp,
 import { describeArchiveFailure, isStaleArchiveFailure, summarizeArchiveResult } from '@/utils/archiveUtils';
 import { toast } from '../common/toast-config';
 import { ConfirmDialog } from '../common/confirm-dialog';
+import { PublishRepositoryDialog } from './publish-repository-dialog';
+import { enabledIntegrations } from '@/utils/message-publish';
 import {
   Table,
   TableBody,
@@ -72,6 +74,7 @@ export function RepositoryTable({
   itemsPerPage,
   searchTerm,
   nextPostId,
+  integrations,
   onRepositoryUpdate,
   onRepositoryArchived
 }: RepositoryTableProps) {
@@ -82,7 +85,7 @@ export function RepositoryTable({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<Repository | null>(null);
   const [showArchiveConfirm, setShowArchiveConfirm] = useState<Repository | null>(null);
   const [archivingId, setArchivingId] = useState<number | null>(null);
-  const [showPromoteConfirm, setShowPromoteConfirm] = useState<Repository | null>(null);
+  const [publishTarget, setPublishTarget] = useState<Repository | null>(null);
   const [promotingId, setPromotingId] = useState<number | null>(null);
   const textInputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -259,7 +262,12 @@ export function RepositoryTable({
 
     try {
       setPromotingId(repo.id);
-      await promoteRepositoryToNext({ id: repo.id });
+      const result = await promoteRepositoryToNext({ id: repo.id });
+      // An unconfigured API answers with an error payload instead of throwing, and
+      // reporting success for a request that never left the browser is a lie.
+      if (result.status === 'error') {
+        throw new Error(result.message);
+      }
 
       toast.success(`Repository will be published next`, {
         ...toastOptions,
@@ -275,6 +283,8 @@ export function RepositoryTable({
         ...toastOptions,
         id: `promote-error-${repo.id}`
       });
+      // Rethrown so the publish dialog keeps itself open on a failed promotion.
+      throw error;
     } finally {
       setPromotingId(null);
     }
@@ -411,16 +421,16 @@ export function RepositoryTable({
                          <Button
                            variant="ghost"
                            size="icon"
-                           onClick={() => setShowPromoteConfirm(repo)}
-                           disabled={repo.id === nextPostId || promotingId !== null}
-                           aria-label={repo.id === nextPostId ? 'Already next' : 'Publish next'}
+                           onClick={() => setPublishTarget(repo)}
+                           disabled={!isApiReady || promotingId !== null}
+                           aria-label="Publish"
                            className="h-8 w-8 text-muted-foreground hover:text-foreground disabled:opacity-50"
                          >
                            <Send className="h-4 w-4" />
                          </Button>
                        </span>
                      </TooltipTrigger>
-                     <TooltipContent>{repo.id === nextPostId ? 'Already next' : 'Publish next'}</TooltipContent>
+                     <TooltipContent>Publish</TooltipContent>
                    </Tooltip>
                  </TooltipProvider>
                )}
@@ -546,20 +556,18 @@ export function RepositoryTable({
         onCancel={() => setShowArchiveConfirm(null)}
       />
 
-      <ConfirmDialog
-        isOpen={showPromoteConfirm !== null}
-        title="Publish Next"
-        message="Publish this repository in the next posting cycle?"
-        confirmText="Publish"
-        cancelText="Cancel"
-        variant="info"
-        onConfirm={() => {
-          if (showPromoteConfirm) {
-            handlePromoteRepository(showPromoteConfirm);
+      <PublishRepositoryDialog
+        repository={publishTarget}
+        isNext={publishTarget !== null && publishTarget.id === nextPostId}
+        isApiReady={isApiReady}
+        integrations={enabledIntegrations(integrations ?? [])}
+        onClose={() => setPublishTarget(null)}
+        onPromote={handlePromoteRepository}
+        onPublished={async () => {
+          if (onRepositoryUpdate) {
+            await onRepositoryUpdate();
           }
-          setShowPromoteConfirm(null);
         }}
-        onCancel={() => setShowPromoteConfirm(null)}
       />
     </>
   );

--- a/src/components/ui/business/repository-table.tsx
+++ b/src/components/ui/business/repository-table.tsx
@@ -75,6 +75,7 @@ export function RepositoryTable({
   searchTerm,
   nextPostId,
   integrations,
+  integrationsLoading,
   onRepositoryUpdate,
   onRepositoryArchived
 }: RepositoryTableProps) {
@@ -86,6 +87,9 @@ export function RepositoryTable({
   const [showArchiveConfirm, setShowArchiveConfirm] = useState<Repository | null>(null);
   const [archivingId, setArchivingId] = useState<number | null>(null);
   const [publishTarget, setPublishTarget] = useState<Repository | null>(null);
+  // One dialog instance serves every row, so retargeting it while it is working
+  // would leave a request writing its outcome into somebody else's repository.
+  const [publishBusy, setPublishBusy] = useState(false);
   const [promotingId, setPromotingId] = useState<number | null>(null);
   const textInputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -258,10 +262,19 @@ export function RepositoryTable({
   };
 
   const handlePromoteRepository = async (repo: Repository) => {
-    if (repo.posted || repo.id === nextPostId || promotingId !== null) return;
+    if (promotingId !== null) return;
 
     try {
       setPromotingId(repo.id);
+      // nextPostId is a render-time value, so another tab - or the cron - can have
+      // moved the queue on since this row was drawn. Saying so beats closing the
+      // dialog as if a promotion that never happened had succeeded.
+      if (repo.posted) {
+        throw new Error('Repository is already published');
+      }
+      if (repo.id === nextPostId) {
+        throw new Error('Repository is already next in the queue');
+      }
       const result = await promoteRepositoryToNext({ id: repo.id });
       // An unconfigured API answers with an error payload instead of throwing, and
       // reporting success for a request that never left the browser is a lie.
@@ -422,15 +435,17 @@ export function RepositoryTable({
                            variant="ghost"
                            size="icon"
                            onClick={() => setPublishTarget(repo)}
-                           disabled={!isApiReady || promotingId !== null}
-                           aria-label="Publish"
+                           disabled={!isApiReady || promotingId !== null || publishBusy}
+                           aria-label={repo.id === nextPostId ? 'Publish (already next in the queue)' : 'Publish'}
                            className="h-8 w-8 text-muted-foreground hover:text-foreground disabled:opacity-50"
                          >
                            <Send className="h-4 w-4" />
                          </Button>
                        </span>
                      </TooltipTrigger>
-                     <TooltipContent>Publish</TooltipContent>
+                     <TooltipContent>
+                       {repo.id === nextPostId ? 'Publish (already next in the queue)' : 'Publish'}
+                     </TooltipContent>
                    </Tooltip>
                  </TooltipProvider>
                )}
@@ -561,7 +576,9 @@ export function RepositoryTable({
         isNext={publishTarget !== null && publishTarget.id === nextPostId}
         isApiReady={isApiReady}
         integrations={enabledIntegrations(integrations ?? [])}
+        integrationsLoading={integrationsLoading}
         onClose={() => setPublishTarget(null)}
+        onBusyChange={setPublishBusy}
         onPromote={handlePromoteRepository}
         onPublished={async () => {
           if (onRepositoryUpdate) {

--- a/src/components/ui/layout/dashboard-content.tsx
+++ b/src/components/ui/layout/dashboard-content.tsx
@@ -409,6 +409,7 @@ export const DashboardContent = ({
               fetchPreviews={fetchPreviews}
               nextPostId={nextPost?.id}
               integrations={apiConfigs}
+              integrationsLoading={apiConfigsLoading}
               currentPage={pagination.currentPage}
               pageSize={pagination.pageSize}
               totalPages={pagination.totalPages}

--- a/src/components/ui/layout/dashboard-content.tsx
+++ b/src/components/ui/layout/dashboard-content.tsx
@@ -408,6 +408,7 @@ export const DashboardContent = ({
               fetchRepositories={fetchRepositories}
               fetchPreviews={fetchPreviews}
               nextPostId={nextPost?.id}
+              integrations={apiConfigs}
               currentPage={pagination.currentPage}
               pageSize={pagination.pageSize}
               totalPages={pagination.totalPages}

--- a/src/types/repositoryList.ts
+++ b/src/types/repositoryList.ts
@@ -33,6 +33,8 @@ export interface RepositoryTableProps {
   nextPostId?: number;
   /** Integration configs, so the publish dialog can list the enabled ones. */
   integrations?: ApiConfig[];
+  /** True while those configs are still being fetched. */
+  integrationsLoading?: boolean;
   onRepositoryUpdate?: () => void | Promise<void>;
   onRepositoryArchived?: () => void | Promise<void>;
 }
@@ -47,6 +49,8 @@ export interface RepositoryMobileViewProps {
   nextPostId?: number;
   /** Integration configs, so the publish dialog can list the enabled ones. */
   integrations?: ApiConfig[];
+  /** True while those configs are still being fetched. */
+  integrationsLoading?: boolean;
   onRepositoryUpdate?: () => void | Promise<void>;
   onRepositoryArchived?: () => void | Promise<void>;
 }

--- a/src/types/repositoryList.ts
+++ b/src/types/repositoryList.ts
@@ -1,3 +1,4 @@
+import type { ApiConfig } from '../api/api-configs';
 import type { Repository, RepositorySortBy, RepositorySortOrder, RepositoryStatusFilter } from '../types';
 
 export interface TruncatedTextProps {
@@ -30,6 +31,8 @@ export interface RepositoryTableProps {
   itemsPerPage: number;
   searchTerm: string;
   nextPostId?: number;
+  /** Integration configs, so the publish dialog can list the enabled ones. */
+  integrations?: ApiConfig[];
   onRepositoryUpdate?: () => void | Promise<void>;
   onRepositoryArchived?: () => void | Promise<void>;
 }
@@ -42,6 +45,8 @@ export interface RepositoryMobileViewProps {
   itemsPerPage: number;
   searchTerm: string;
   nextPostId?: number;
+  /** Integration configs, so the publish dialog can list the enabled ones. */
+  integrations?: ApiConfig[];
   onRepositoryUpdate?: () => void | Promise<void>;
   onRepositoryArchived?: () => void | Promise<void>;
 }

--- a/src/utils/message-publish.test.ts
+++ b/src/utils/message-publish.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import type { ApiConfig } from '@/api/api-configs';
+import type { RetryMessageResult } from '@/api/index';
+import {
+  buildPublishRows,
+  enabledIntegrations,
+  publishedSomething,
+  summarizePublishResult,
+} from './message-publish';
+
+const config = (overrides: Partial<ApiConfig>): ApiConfig => ({
+  id: 1,
+  name: 'threads',
+  url: 'http://threads-connector:9016/threads/post',
+  method: 'POST',
+  auth_type: 'api_key',
+  token_env_var: 'THREADS_API_KEY',
+  token_header: 'X-API-Key',
+  content_type: 'json',
+  timeout: 90,
+  success_code: 200,
+  enabled: true,
+  response_type: 'json',
+  text_language: 'en',
+  socialify_image: false,
+  default_json_body: '',
+  updated_at: '2026-08-17T16:00:00Z',
+  ...overrides,
+});
+
+const result = (overrides: Partial<RetryMessageResult>): RetryMessageResult => ({
+  url: 'https://github.com/a/b',
+  status: 1,
+  message: 'Manual publish: https://github.com/a/b sent to: threads',
+  ...overrides,
+});
+
+const telegram = { name: 'telegram', textLanguage: 'uk' };
+const threads = { name: 'threads', textLanguage: 'en' };
+
+describe('enabledIntegrations', () => {
+  it('keeps only the enabled ones, sorted the way Content Maestro reports them', () => {
+    expect(enabledIntegrations([
+      config({ name: 'threads', text_language: 'en' }),
+      config({ name: 'bluesky', enabled: false }),
+      config({ name: 'telegram', text_language: 'uk' }),
+    ])).toEqual([telegram, threads]);
+  });
+
+  it('returns nothing when every integration is disabled', () => {
+    expect(enabledIntegrations([config({ enabled: false })])).toEqual([]);
+  });
+});
+
+describe('buildPublishRows', () => {
+  it('shows every expected integration as pending before the run answers', () => {
+    expect(buildPublishRows([telegram, threads])).toEqual([
+      { name: 'telegram', state: 'pending', textLanguage: 'uk' },
+      { name: 'threads', state: 'pending', textLanguage: 'en' },
+    ]);
+  });
+
+  it('resolves the rows from the reported outcomes', () => {
+    expect(buildPublishRows([telegram, threads], result({
+      status: 2,
+      succeeded: ['telegram'],
+      failed: ['threads'],
+      outcomes: [
+        { api_name: 'telegram', success: true },
+        { api_name: 'threads', success: false, error: 'API request failed with status 500' },
+      ],
+    }))).toEqual([
+      { name: 'telegram', state: 'success', error: undefined, textLanguage: 'uk' },
+      { name: 'threads', state: 'failure', error: 'API request failed with status 500', textLanguage: 'en' },
+    ]);
+  });
+
+  // Go marshals empty slices as null, so the outcomes can be missing entirely
+  // while the name lists still say what happened.
+  it('falls back to the name lists when no outcomes came back', () => {
+    expect(buildPublishRows([telegram, threads], result({
+      status: 2,
+      succeeded: ['telegram'],
+      failed: ['threads'],
+      outcomes: null,
+    }))).toEqual([
+      { name: 'telegram', state: 'success', error: undefined, textLanguage: 'uk' },
+      { name: 'threads', state: 'failure', error: 'unknown error', textLanguage: 'en' },
+    ]);
+  });
+
+  it('names a failure with no message rather than leaving it blank', () => {
+    expect(buildPublishRows([threads], result({
+      status: 0,
+      outcomes: [{ api_name: 'threads', success: false, error: '  ' }],
+    }))[0]).toEqual({ name: 'threads', state: 'failure', error: 'unknown error', textLanguage: 'en' });
+  });
+
+  // An integration enabled in another tab is published to but is missing from
+  // this dashboard's cached list, so the run is what decides it exists.
+  it('includes an integration the run reported but the dashboard did not expect', () => {
+    expect(buildPublishRows([threads], result({
+      succeeded: ['threads', 'bluesky'],
+      outcomes: [
+        { api_name: 'threads', success: true },
+        { api_name: 'bluesky', success: true },
+      ],
+    }))).toEqual([
+      { name: 'threads', state: 'success', error: undefined, textLanguage: 'en' },
+      { name: 'bluesky', state: 'success', error: undefined, textLanguage: undefined },
+    ]);
+  });
+
+  // The opposite case: an integration disabled since the list was cached never
+  // gets an outcome, and silently showing it as fine would be a lie.
+  it('treats an expected integration with no reported outcome as a failure', () => {
+    expect(buildPublishRows([telegram, threads], result({
+      succeeded: ['threads'],
+      outcomes: [{ api_name: 'threads', success: true }],
+    }))).toEqual([
+      { name: 'telegram', state: 'failure', error: 'no result reported', textLanguage: 'uk' },
+      { name: 'threads', state: 'success', error: undefined, textLanguage: 'en' },
+    ]);
+  });
+});
+
+describe('summarizePublishResult', () => {
+  it('reports a full success', () => {
+    const summary = summarizePublishResult(result({ status: 1, succeeded: ['telegram', 'threads'] }));
+    expect(summary.tone).toBe('success');
+    expect(summary.text).toContain('all 2 integrations');
+  });
+
+  it('reports a partial success and points at the retry', () => {
+    const summary = summarizePublishResult(result({
+      status: 2,
+      succeeded: ['telegram'],
+      failed: ['threads'],
+    }));
+    expect(summary.tone).toBe('partial');
+    expect(summary.text).toContain('1 of 2');
+    expect(summary.text).toContain('Cron History');
+  });
+
+  it('reports a run that published nothing and says the item stays queued', () => {
+    const summary = summarizePublishResult(result({ status: 0, succeeded: null, failed: ['threads'] }));
+    expect(summary.tone).toBe('error');
+    expect(summary.text).toContain('stays in the queue');
+  });
+});
+
+describe('publishedSomething', () => {
+  it.each([
+    ['no result', undefined, false],
+    ['a null list', result({ succeeded: null }), false],
+    ['an empty list', result({ succeeded: [] }), false],
+    ['one integration', result({ succeeded: ['threads'] }), true],
+  ])('%s', (_name, value, expected) => {
+    expect(publishedSomething(value as RetryMessageResult | undefined)).toBe(expected);
+  });
+});

--- a/src/utils/message-publish.test.ts
+++ b/src/utils/message-publish.test.ts
@@ -126,7 +126,11 @@ describe('buildPublishRows', () => {
 
 describe('summarizePublishResult', () => {
   it('reports a full success', () => {
-    const summary = summarizePublishResult(result({ status: 1, succeeded: ['telegram', 'threads'] }));
+    const summary = summarizePublishResult(result({
+      status: 1,
+      succeeded: ['telegram', 'threads'],
+      posted: true,
+    }));
     expect(summary.tone).toBe('success');
     expect(summary.text).toContain('all 2 integrations');
   });
@@ -136,10 +140,38 @@ describe('summarizePublishResult', () => {
       status: 2,
       succeeded: ['telegram'],
       failed: ['threads'],
+      posted: true,
     }));
     expect(summary.tone).toBe('partial');
     expect(summary.text).toContain('1 of 2');
     expect(summary.text).toContain('Cron History');
+  });
+
+  // Sending someone to "Publish again" for an item that never left the queue
+  // would have the scheduled run repost it to the integrations that already
+  // have it, so the queue sentence follows `posted` and not the counts.
+  it('does not claim the item left the queue when marking it posted failed', () => {
+    const summary = summarizePublishResult(result({
+      status: 2,
+      succeeded: ['telegram'],
+      failed: ['threads'],
+      posted: false,
+      posted_error: 'context deadline exceeded',
+    }));
+    expect(summary.tone).toBe('partial');
+    expect(summary.text).toContain('still in the queue');
+    expect(summary.text).not.toContain('Cron History');
+  });
+
+  it('downgrades an otherwise complete run that stayed in the queue', () => {
+    const summary = summarizePublishResult(result({
+      status: 1,
+      succeeded: ['telegram', 'threads'],
+      posted: false,
+      posted_error: 'context deadline exceeded',
+    }));
+    expect(summary.tone).toBe('partial');
+    expect(summary.text).toContain('still in the queue');
   });
 
   it('reports a run that published nothing and says the item stays queued', () => {

--- a/src/utils/message-publish.ts
+++ b/src/utils/message-publish.ts
@@ -98,7 +98,14 @@ export const buildPublishRows = (
   return [...ordered, ...extras];
 };
 
-/** Wording and tone of the banner above the result rows. */
+/**
+ * Wording and tone of the banner above the result rows.
+ *
+ * What it says about the queue follows `posted`, not the success counts: marking
+ * the repository as published can fail on its own, and telling someone the item
+ * left the queue when it did not would send them to "Publish again" for a repost
+ * the scheduled run is about to do anyway.
+ */
 export const summarizePublishResult = (result: RetryMessageResult): PublishSummary => {
   const succeeded = result.succeeded ?? [];
   const failed = result.failed ?? [];
@@ -114,13 +121,18 @@ export const summarizePublishResult = (result: RetryMessageResult): PublishSumma
     return {
       tone: 'partial',
       text: `Published to ${succeeded.length} of ${succeeded.length + failed.length} integrations. `
-        + 'The repository left the queue, so finish the rest with "Publish again" in Cron History.',
+        + (result.posted
+          ? 'The repository left the queue, so finish the rest with "Publish again" in Cron History.'
+          : 'The repository is still in the queue, so the scheduled run will publish it again.'),
     };
   }
 
+  const reach = succeeded.length === 1 ? 'the integration' : `all ${succeeded.length} integrations`;
+
   return {
-    tone: 'success',
-    text: `Published to ${succeeded.length === 1 ? 'the integration' : `all ${succeeded.length} integrations`}.`,
+    tone: result.posted === false ? 'partial' : 'success',
+    text: `Published to ${reach}.`
+      + (result.posted === false ? ' The repository is still in the queue, so the scheduled run will publish it again.' : ''),
   };
 };
 

--- a/src/utils/message-publish.ts
+++ b/src/utils/message-publish.ts
@@ -1,0 +1,129 @@
+import type { ApiConfig } from '../api/api-configs';
+import type { RetryMessageResult } from '../api/index';
+
+export interface PublishIntegration {
+  name: string;
+  textLanguage?: string;
+}
+
+export type PublishRowState = 'pending' | 'success' | 'failure';
+
+export interface PublishRow {
+  name: string;
+  state: PublishRowState;
+  error?: string;
+  textLanguage?: string;
+}
+
+export interface PublishSummary {
+  tone: 'success' | 'partial' | 'error';
+  text: string;
+}
+
+/**
+ * The integrations a publish-now will reach, in the order Content Maestro reports
+ * them (it sorts by name, because its own configuration is a map). Matching that
+ * order keeps the list the dialog shows before the run identical to the list of
+ * results it shows afterwards.
+ */
+export const enabledIntegrations = (configs: ApiConfig[]): PublishIntegration[] =>
+  configs
+    .filter(config => config.enabled)
+    .map(config => ({ name: config.name, textLanguage: config.text_language }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+/**
+ * Merges what the dashboard expected with what the run reported.
+ *
+ * Content Maestro is authoritative: it resolves the enabled integrations at
+ * request time, so a run can report an integration this dashboard's cached list
+ * does not know about (enabled in another tab) and can omit one the cached list
+ * still carries (disabled since). Rows are therefore built from both, and an
+ * expected integration with no reported outcome is a failure rather than a
+ * silent success.
+ */
+export const buildPublishRows = (
+  expected: PublishIntegration[],
+  result?: RetryMessageResult | null
+): PublishRow[] => {
+  const languages = new Map(expected.map(integration => [integration.name, integration.textLanguage]));
+
+  if (!result) {
+    return expected.map(integration => ({
+      name: integration.name,
+      state: 'pending',
+      textLanguage: integration.textLanguage,
+    }));
+  }
+
+  const rows = new Map<string, PublishRow>();
+
+  const record = (name: string, state: PublishRowState, error?: string) => {
+    rows.set(name, { name, state, error, textLanguage: languages.get(name) });
+  };
+
+  const outcomes = result.outcomes ?? [];
+  if (outcomes.length > 0) {
+    for (const outcome of outcomes) {
+      if (outcome.success) {
+        record(outcome.api_name, 'success');
+      } else {
+        record(outcome.api_name, 'failure', outcome.error?.trim() || 'unknown error');
+      }
+    }
+  } else {
+    // Go marshals empty slices as null, so a run can come back with the name
+    // lists filled in and no outcomes at all.
+    for (const name of result.succeeded ?? []) {
+      record(name, 'success');
+    }
+    for (const name of result.failed ?? []) {
+      record(name, 'failure', 'unknown error');
+    }
+  }
+
+  for (const integration of expected) {
+    if (!rows.has(integration.name)) {
+      record(integration.name, 'failure', 'no result reported');
+    }
+  }
+
+  // Expected integrations first, in their own order; anything the run added on
+  // top of them goes after, so the list the user was looking at does not jump.
+  const ordered = expected
+    .map(integration => rows.get(integration.name))
+    .filter((row): row is PublishRow => row !== undefined);
+  const extras = [...rows.values()].filter(row => !languages.has(row.name));
+
+  return [...ordered, ...extras];
+};
+
+/** Wording and tone of the banner above the result rows. */
+export const summarizePublishResult = (result: RetryMessageResult): PublishSummary => {
+  const succeeded = result.succeeded ?? [];
+  const failed = result.failed ?? [];
+
+  if (succeeded.length === 0) {
+    return {
+      tone: 'error',
+      text: 'Not published: no integration accepted the post. The repository stays in the queue.',
+    };
+  }
+
+  if (failed.length > 0) {
+    return {
+      tone: 'partial',
+      text: `Published to ${succeeded.length} of ${succeeded.length + failed.length} integrations. `
+        + 'The repository left the queue, so finish the rest with "Publish again" in Cron History.',
+    };
+  }
+
+  return {
+    tone: 'success',
+    text: `Published to ${succeeded.length === 1 ? 'the integration' : `all ${succeeded.length} integrations`}.`,
+  };
+};
+
+/** True when at least one integration accepted the post, so the parent must refresh. */
+export const publishedSomething = (result?: RetryMessageResult | null): boolean =>
+  (result?.succeeded ?? []).length > 0;


### PR DESCRIPTION
## Why

The send button on a repository row promoted it to the head of the publication queue and nothing more, so a post that has to go out **now** still waited for the scheduled run. After a bad record was deleted from the queue once it had already been published, there was no way to get a replacement post out at all.

## What

The button now opens a dialog with both choices:

- **Publish next** — the existing promotion to the head of the queue.
- **Publish now** — publishes immediately to every enabled integration, through content-maestro's new `POST /api/message/publish` (think-root/content-maestro#3).

The publication status is shown **inside the dialog** rather than as a toast, because that is the only place the per-integration outcome fits: one row per integration, a spinner while the request is in flight, then *sent* or *failed* with the error the connector reported, above a summary banner.

### Deliberate choices

- **No faked progress.** The backend is a single synchronous call, so rows go spinner → final result in one step. Flipping a row to *sent* on a timer would be a lie about a publication. (SSE would be honest but costs a second response mode, a hand-rolled stream parser, and dies behind any buffering proxy, to learn ~30 s earlier which connector is slow.)
- **The integration list costs no extra request** — it comes from the `api-configs` the dashboard already loads. Content Maestro still resolves the enabled set itself, so a run can report an integration this tab's cached list does not know about (enabled in another tab) and can omit one the list still carries (disabled since). Rows are built from both, and an expected integration with **no** reported outcome is shown as a failure rather than silently as a success.
- **The send button is no longer disabled on the row that is already next.** That is precisely the row most likely to need publishing now; only the *Publish next* action inside the dialog is disabled for it.
- **The 240 s abort is a safety net, not a cancellation.** Aborting does not stop the run on the server, so the message says the publication may still be running and points at Cron History, instead of claiming it failed. A shorter timeout would read a legitimate 90 s Threads post as a failure. The dialog cannot be dismissed while a request is in flight, so its result is never thrown away.
- **A request that never produced a result leaves the choices in place** with the error above them: the `409` refusals (a cron run holding the lock, an item already published) are worth another try, and the backend refuses a duplicate on its own.

### Also fixes

`promoteRepositoryToNext` answers an unconfigured API with an error payload instead of throwing, and both handlers ignored it — so an unconfigured dashboard toasted "Repository will be published next" after doing nothing at all.

## Tests

`npx vitest run` — 26/26. 12 new tests in `src/utils/message-publish.test.ts` cover the row-merging edge cases (no result yet, outcomes present, Go's `null` for empty slices, a failure with no message, a reported integration the dashboard did not expect, an expected one with no outcome) plus the summary tones.

`npx tsc -b --force` and `npm run build` are clean apart from two **pre-existing** errors in `src/hooks/useRepositories.ts:396,411` that this branch does not touch.

`npx eslint src` could not be run: it is broken on `main` for unrelated reasons — `Error while loading rule '@typescript-eslint/no-unused-expressions'`, failing on the untouched `src/api/api-configs.ts`.

## Manual check worth doing

1. Unposted row → send → **Publish next** → toast, row becomes head of the queue.
2. **Publish now** with one integration disabled → only the enabled ones are listed.
3. **Publish now** with a connector pointed at a dead URL → per-integration ✗ with its error, the row still leaves the queue, and Cron History shows a manual run with a working "Publish again".
4. Content Maestro stopped → "Failed to connect to Content Maestro API".
5. The same row in two tabs → the second gets "repository is already published".
6. Mobile viewport for `repository-mobile-view`.
